### PR TITLE
Add sidebar navigation and pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,11 @@ Write unit tests in `*.test.ts` beside source files. Achieve ≥ 80 % statement 
 ## Usage notes for Codex
 When adding new features, update corresponding domain model first, then UI. Run `npm run lint` and ensure tests pass before committing.
 For project information and structure read `README.md`. 
+
+## Styleguide
+- Use Tailwind CSS utility classes exclusively for styling.
+- Primary color: `blue-600` for interactive elements.
+- Buttons: `px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700`.
+- Cards and panels: `bg-white shadow rounded p-4` with `text-gray-800`.
+- Sidebar background: `bg-gray-800 text-white`; header background uses the primary color.
+- Keep typography simple: `text-xl font-bold` for page titles.

--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,5 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  height: 100%;
 }
 
 .logo {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,31 @@
-import GoalList from './ui/GoalList'
-import ProjectList from './ui/ProjectList'
-import TaskList from './ui/TaskList'
-import { useStore } from './domain/store'
+import { useState } from 'react'
+import Header from './ui/components/Header'
+import Sidebar from './ui/components/Sidebar'
+import HomePage from './ui/pages/HomePage'
+import GoalsPage from './ui/pages/GoalsPage'
+import ProjectsPage from './ui/pages/ProjectsPage'
+import HabitsPage from './ui/pages/HabitsPage'
+import { useNavStore } from './domain/navigation'
 import './App.css'
 
 export default function App() {
-  const { goals } = useStore()
+  const { page } = useNavStore()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const handleNavigate = () => setSidebarOpen(false)
+
+  let content
+  if (page === 'Home') content = <HomePage />
+  if (page === 'Goals') content = <GoalsPage />
+  if (page === 'Projects') content = <ProjectsPage />
+  if (page === 'Habits') content = <HabitsPage />
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold text-center">LifeManager</h1>
-      <GoalList />
-      {goals.map((g) => (
-        <div key={g.id} className="ml-4">
-          <ProjectList goalId={g.id} />
-          {g.projects.map((p) => (
-            <div key={p.id} className="ml-4">
-              <TaskList projectId={p.id} />
-            </div>
-          ))}
-        </div>
-      ))}
+    <div className="h-screen flex">
+      <Sidebar open={sidebarOpen} onNavigate={handleNavigate} />
+      <div className="flex flex-col flex-1 overflow-hidden">
+        <Header onMenu={() => setSidebarOpen(!sidebarOpen)} />
+        <main className="p-4 overflow-auto flex-1 bg-gray-50">{content}</main>
+      </div>
     </div>
   )
 }

--- a/src/domain/navigation.test.ts
+++ b/src/domain/navigation.test.ts
@@ -1,0 +1,7 @@
+import { useNavStore } from './navigation'
+
+it('changes page', () => {
+  const { setPage } = useNavStore.getState()
+  setPage('Goals')
+  expect(useNavStore.getState().page).toBe('Goals')
+})

--- a/src/domain/navigation.ts
+++ b/src/domain/navigation.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+export type Page = 'Home' | 'Habits' | 'Projects' | 'Goals'
+
+interface NavState {
+  page: Page
+  setPage: (p: Page) => void
+}
+
+export const useNavStore = create<NavState>((set) => ({
+  page: 'Home',
+  setPage: (p) => set({ page: p }),
+}))

--- a/src/domain/store.test.ts
+++ b/src/domain/store.test.ts
@@ -12,3 +12,36 @@ it('adds a goal', () => {
   })
   expect(useStore.getState().goals.length).toBe(goals.length + 1)
 })
+
+it('removes a goal', () => {
+  const { addGoal, removeGoal } = useStore.getState()
+  addGoal({
+    id: 'remove',
+    name: 'To remove',
+    period: { from: '2024-01-01', to: '2024-12-31' },
+    status: 'Not started',
+    areaOfLife: 'Test',
+    projects: [],
+  })
+  removeGoal('remove')
+  expect(useStore.getState().goals.find((g) => g.id === 'remove')).toBeUndefined()
+})
+it('adds and removes a task', () => {
+  const { addGoal, addProject, addTask, removeTask } = useStore.getState()
+  const goalId = 'g1'
+  const projectId = 'p1'
+  addGoal({
+    id: goalId,
+    name: 'goal',
+    period: { from: '2024-01-01', to: '2024-12-31' },
+    status: 'Not started',
+    areaOfLife: 'Test',
+    projects: [],
+  })
+  addProject(goalId, { id: projectId, goalId, name: 'proj', period: { from: '2024-01-01', to: '2024-12-31' }, status: 'Not started', tasks: [] })
+  const taskId = 't1'
+  addTask(projectId, { id: taskId, name: 'task', description: '', duration: 60, priority: 3, dependencyIds: [], completed: false, date: '2024-06-01' })
+  expect(useStore.getState().goals.find(g=>g.id===goalId)?.projects[0].tasks.length).toBe(1)
+  removeTask(projectId, taskId)
+  expect(useStore.getState().goals.find(g=>g.id===goalId)?.projects[0].tasks.length).toBe(0)
+})

--- a/src/domain/store.ts
+++ b/src/domain/store.ts
@@ -4,17 +4,33 @@ import type { Goal, Project, Task } from './types'
 interface State {
   goals: Goal[]
   addGoal: (goal: Goal) => void
+  removeGoal: (goalId: string) => void
   addProject: (goalId: string, project: Project) => void
+  removeProject: (goalId: string, projectId: string) => void
   addTask: (projectId: string, task: Task) => void
+  removeTask: (projectId: string, taskId: string) => void
 }
 
 export const useStore = create<State>((set) => ({
   goals: [],
   addGoal: (goal) => set((s) => ({ goals: [...s.goals, goal] })),
+  removeGoal: (goalId) =>
+    set((s) => ({ goals: s.goals.filter((g) => g.id !== goalId) })),
   addProject: (goalId, project) =>
     set((s) => ({
       goals: s.goals.map((g) =>
         g.id === goalId ? { ...g, projects: [...g.projects, project] } : g
+      ),
+    })),
+  removeProject: (goalId, projectId) =>
+    set((s) => ({
+      goals: s.goals.map((g) =>
+        g.id === goalId
+          ? {
+              ...g,
+              projects: g.projects.filter((p) => p.id !== projectId),
+            }
+          : g
       ),
     })),
   addTask: (projectId, task) =>
@@ -23,6 +39,17 @@ export const useStore = create<State>((set) => ({
         ...g,
         projects: g.projects.map((p) =>
           p.id === projectId ? { ...p, tasks: [...p.tasks, task] } : p
+        ),
+      })),
+    })),
+  removeTask: (projectId, taskId) =>
+    set((s) => ({
+      goals: s.goals.map((g) => ({
+        ...g,
+        projects: g.projects.map((p) =>
+          p.id === projectId
+            ? { ...p, tasks: p.tasks.filter((t) => t.id !== taskId) }
+            : p
         ),
       })),
     })),

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -6,6 +6,7 @@ export interface Task {
   priority: number; // 1-5
   dependencyIds: string[];
   completed: boolean;
+  date: string; // ISO date
 }
 
 export interface Project {

--- a/src/index.css
+++ b/src/index.css
@@ -26,8 +26,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }

--- a/src/ui/GoalList.tsx
+++ b/src/ui/GoalList.tsx
@@ -1,20 +1,39 @@
 import { useState } from 'react'
 import { useStore } from '../domain/store'
-import type { Goal } from '../domain/types'
+import type { Goal, Project, Task } from '../domain/types'
 
 export default function GoalList() {
-  const { goals, addGoal } = useStore()
+  const { goals, addGoal, removeGoal } = useStore()
   const [name, setName] = useState('')
 
   const handleAdd = () => {
     if (!name) return
-    const goal: Goal = {
+    const id = Math.random().toString(36).slice(2)
+    const task: Task = {
       id: Math.random().toString(36).slice(2),
+      name: 'Sample Task',
+      description: '',
+      duration: 60,
+      priority: 3,
+      dependencyIds: [],
+      completed: false,
+      date: new Date().toISOString().slice(0, 10),
+    }
+    const project: Project = {
+      id: Math.random().toString(36).slice(2),
+      goalId: id,
+      name: 'Sample Project',
+      period: { from: new Date().toISOString(), to: new Date().toISOString() },
+      status: 'Not started',
+      tasks: [task],
+    }
+    const goal: Goal = {
+      id,
       name,
       period: { from: new Date().toISOString(), to: new Date().toISOString() },
       status: 'Not started',
       areaOfLife: 'General',
-      projects: [],
+      projects: [project],
     }
     addGoal(goal)
     setName('')
@@ -25,8 +44,16 @@ export default function GoalList() {
       <h2 className="text-xl font-bold mb-2">Goals</h2>
       <ul className="mb-4">
         {goals.map((g) => (
-          <li key={g.id} className="border p-2 mb-2 rounded">
-            {g.name} - {g.status}
+          <li key={g.id} className="border p-2 mb-2 rounded flex justify-between items-center">
+            <span>
+              {g.name} - {g.status}
+            </span>
+            <button
+              onClick={() => removeGoal(g.id)}
+              className="px-2 py-1 rounded bg-blue-600 text-white hover:bg-blue-700"
+            >
+              Delete
+            </button>
           </li>
         ))}
       </ul>

--- a/src/ui/ProjectList.tsx
+++ b/src/ui/ProjectList.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 import { useStore } from '../domain/store'
-import type { Project } from '../domain/types'
+import type { Project, Task } from '../domain/types'
 
 interface Props {
   goalId: string
 }
 
 export default function ProjectList({ goalId }: Props) {
-  const { goals, addProject } = useStore()
+  const { goals, addProject, removeProject } = useStore()
   const goal = goals.find((g) => g.id === goalId)
   const [name, setName] = useState('')
 
@@ -15,13 +15,24 @@ export default function ProjectList({ goalId }: Props) {
 
   const handleAdd = () => {
     if (!name) return
-    const project: Project = {
+    const id = Math.random().toString(36).slice(2)
+    const task: Task = {
       id: Math.random().toString(36).slice(2),
+      name: 'Sample Task',
+      description: '',
+      duration: 60,
+      priority: 3,
+      dependencyIds: [],
+      completed: false,
+      date: new Date().toISOString().slice(0, 10),
+    }
+    const project: Project = {
+      id,
       goalId,
       name,
       period: { from: new Date().toISOString(), to: new Date().toISOString() },
       status: 'Not started',
-      tasks: [],
+      tasks: [task],
     }
     addProject(goalId, project)
     setName('')
@@ -32,8 +43,19 @@ export default function ProjectList({ goalId }: Props) {
       <h3 className="font-semibold mb-2">Projects for {goal.name}</h3>
       <ul className="mb-2">
         {goal.projects.map((p) => (
-          <li key={p.id} className="border p-1 mb-1 rounded">
-            {p.name} - {p.status}
+          <li
+            key={p.id}
+            className="border p-1 mb-1 rounded flex justify-between items-center"
+          >
+            <span>
+              {p.name} - {p.status}
+            </span>
+            <button
+              onClick={() => removeProject(goalId, p.id)}
+              className="px-2 py-1 rounded bg-blue-600 text-white hover:bg-blue-700"
+            >
+              Delete
+            </button>
           </li>
         ))}
       </ul>

--- a/src/ui/TaskList.tsx
+++ b/src/ui/TaskList.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 export default function TaskList({ projectId }: Props) {
-  const { goals, addTask } = useStore()
+  const { goals, addTask, removeTask } = useStore()
   const project = goals.flatMap((g) => g.projects).find((p) => p.id === projectId)
   const [name, setName] = useState('')
 
@@ -23,6 +23,7 @@ export default function TaskList({ projectId }: Props) {
       priority: 3,
       dependencyIds: [],
       completed: false,
+      date: new Date().toISOString().slice(0, 10),
     }
     addTask(projectId, task)
     setName('')
@@ -33,8 +34,19 @@ export default function TaskList({ projectId }: Props) {
       <h4 className="font-semibold mb-2">Tasks for {project.name}</h4>
       <ul className="mb-2">
         {project.tasks.map((t) => (
-          <li key={t.id} className="border p-1 mb-1 rounded">
-            {t.name} {t.completed ? '(done)' : ''}
+          <li
+            key={t.id}
+            className="border p-1 mb-1 rounded flex justify-between items-center"
+          >
+            <span>
+              {t.name} {t.completed ? '(done)' : ''}
+            </span>
+            <button
+              onClick={() => removeTask(projectId, t.id)}
+              className="px-2 py-1 rounded bg-blue-600 text-white hover:bg-blue-700"
+            >
+              Delete
+            </button>
           </li>
         ))}
       </ul>

--- a/src/ui/components/Header.tsx
+++ b/src/ui/components/Header.tsx
@@ -1,0 +1,20 @@
+import { Dispatch, SetStateAction } from 'react'
+
+interface Props {
+  onMenu: () => void
+}
+
+export default function Header({ onMenu }: Props) {
+  return (
+    <header className="bg-blue-600 text-white flex items-center p-4">
+      <button
+        className="md:hidden mr-2"
+        onClick={onMenu}
+        aria-label="Menu"
+      >
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+      </button>
+      <h1 className="text-xl font-bold">LifeManager</h1>
+    </header>
+  )
+}

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -1,0 +1,35 @@
+import { useNavStore, Page } from '../../domain/navigation'
+
+interface Props {
+  open: boolean
+  onNavigate: () => void
+}
+
+const links: { label: string; page: Page }[] = [
+  { label: 'Home', page: 'Home' },
+  { label: 'Habits', page: 'Habits' },
+  { label: 'Projects', page: 'Projects' },
+  { label: 'Goals', page: 'Goals' },
+]
+
+export default function Sidebar({ open, onNavigate }: Props) {
+  const { page, setPage } = useNavStore()
+  return (
+    <nav
+      className={`${open ? 'block' : 'hidden'} md:block bg-gray-800 text-white w-60 p-4 space-y-2`}
+    >
+      {links.map((l) => (
+        <button
+          key={l.page}
+          onClick={() => {
+            setPage(l.page)
+            onNavigate()
+          }}
+          className={`block w-full text-left px-3 py-2 rounded hover:bg-gray-700 ${page === l.page ? 'bg-gray-700' : ''}`}
+        >
+          {l.label}
+        </button>
+      ))}
+    </nav>
+  )
+}

--- a/src/ui/pages/GoalsPage.tsx
+++ b/src/ui/pages/GoalsPage.tsx
@@ -1,0 +1,10 @@
+import GoalList from '../GoalList'
+
+export default function GoalsPage() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Goals</h2>
+      <GoalList />
+    </div>
+  )
+}

--- a/src/ui/pages/HabitsPage.tsx
+++ b/src/ui/pages/HabitsPage.tsx
@@ -1,0 +1,3 @@
+export default function HabitsPage() {
+  return <p className="text-gray-800">To be implemented</p>
+}

--- a/src/ui/pages/HomePage.tsx
+++ b/src/ui/pages/HomePage.tsx
@@ -1,0 +1,41 @@
+import { useStore } from '../../domain/store'
+import { useState } from 'react'
+
+export default function HomePage() {
+  const tasks = useStore((s) =>
+    s.goals.flatMap((g) => g.projects.flatMap((p) => p.tasks))
+  )
+  const [view, setView] = useState<'day' | 'week' | 'month'>('month')
+
+  const grouped = tasks.reduce<Record<string, typeof tasks>>((acc, t) => {
+    acc[t.date] = acc[t.date] ? [...acc[t.date], t] : [t]
+    return acc
+  }, {})
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Calendar</h2>
+      <div className="flex gap-2">
+        {(['day', 'week', 'month'] as const).map((v) => (
+          <button
+            key={v}
+            onClick={() => setView(v)}
+            className={`px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 ${view === v ? 'opacity-80' : ''}`}
+          >
+            {v}
+          </button>
+        ))}
+      </div>
+      {Object.keys(grouped).map((d) => (
+        <div key={d} className="bg-white shadow rounded p-4 text-gray-800">
+          <div className="font-semibold mb-2">{d}</div>
+          <ul className="list-disc ml-4">
+            {grouped[d].map((t) => (
+              <li key={t.id}>{t.name}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/ui/pages/ProjectsPage.tsx
+++ b/src/ui/pages/ProjectsPage.tsx
@@ -1,0 +1,19 @@
+import { useStore } from '../../domain/store'
+
+export default function ProjectsPage() {
+  const projects = useStore((s) =>
+    s.goals.flatMap((g) => g.projects.map((p) => ({ ...p, goalName: g.name })))
+  )
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Projects</h2>
+      {projects.map((p) => (
+        <div key={p.id} className="bg-white shadow rounded p-4 text-gray-800">
+          <div className="font-semibold">{p.name}</div>
+          <div className="text-sm text-gray-500">Goal: {p.goalName}</div>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create Tailwind styleguide
- add UI navigation store
- extend domain models with `date` and add CRUD actions
- implement header, sidebar and four pages
- add mock data creation and delete buttons
- update unit tests

## Testing
- `npm run lint`
- `npm test` *(fails: MISSING DEPENDENCY jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_684044b4fe84832b8a01450a52ff9315