### PR TITLE
Update docs to match current stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,10 @@ Guides contributors on repository structure and coding style.
 - `docs/` – project documentation
 
 ## Commands
-- `npm run dev`      – Vite dev server
+- `npm run dev`      – Next.js dev server
 - `npm run build`    – Production PWA build
 - `npm run lint`     – ESLint
 - `npm run electron` – Desktop shell
-- `npm test`         – Vitest unit tests
 
 ## Coding conventions
 - Use TypeScript and React function components.
@@ -25,10 +24,9 @@ Guides contributors on repository structure and coding style.
 - Prefer named exports and keep components small.
 
 ## Testing
-Write unit tests in `*.test.ts` beside source files. Achieve ≥ 80 % statement coverage. Use Vitest.
-
+Unit tests are not yet configured.
 ## Usage notes for Codex
-When adding new features, update corresponding domain model first, then UI. Run `npm run lint` and ensure tests pass before committing.
+When adding new features, update corresponding domain model first, then UI. Run `npm run lint` before committing.
 For project information and structure read `README.md`. 
 
 ## Styleguide

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ LifeManager accelerates personal goal attainment by turning a high-level aspirat
 - Authentication – Google OAuth initiates authorisation; backend issues session JWTs for API calls.
 - Offline Support – Progressive Web App caches critical assets and state; synchronises on reconnection.
 - Desktop Option – Electron shell packages the same codebase for Windows, macOS, and Linux.
-- Unit Testing and CI – Vitest ≥ 80 % coverage, ESLint Airbnb TypeScript rules, GitHub Actions gate merges.
+- CI – ESLint with Airbnb TypeScript rules; GitHub Actions gate merges.
 ## Domain Concepts
 ### Goal
 - Quantitative: track start, current, and target numeric values
@@ -64,18 +64,16 @@ LifeManager accelerates personal goal attainment by turning a high-level aspirat
 - `POST /documents/upload-url` (presign PUT)
 - `POST /calendar/sync`
 ## Tech Stack
-- Client: React, TypeScript, Vite, Tailwind CSS
+- Client: React, TypeScript, Next.js, Tailwind CSS
 - Backend: Language-agnostic REST (reference Node.js), n8n for AI orchestration
 - AI: OpenAI Chat Completions (gpt-4o) and embeddings
 - Storage: PostgreSQL for metadata, S3-compatible bucket for documents
 - Calendar: Google Calendar API v3
 - Desktop: Electron 30 with context isolation
-- Testing: Vitest, Testing Library, MSW
 - CI/CD: GitHub Actions, codecov
 ## Development Workflow
 1. Install dependencies with `npm install`.
 2. Start the dev server using `npm run dev`.
-3. Lint with `npm run lint` and run tests via `npm test`.
+3. Lint with `npm run lint`.
 4. Build production assets with `npm run build`.
-5. Start the desktop shell using `npm run electron`.
 

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -18,7 +18,7 @@ This document outlines the high‑level goals and architecture of the **LifeMana
 - **Calendar**: Google Calendar API for free/busy lookups and event creation.
 
 ## Development Principles
-- Keep components focused and test with Vitest beside each source file.
+- Keep components focused and write unit tests beside each source file.
 - Apply Tailwind utility classes; interactive elements use the `blue-600` palette.
 - Maintain ≥ 80% unit test coverage and run `npm run lint` before committing.
 


### PR DESCRIPTION
## Summary
- remove vitest references
- fix tech stack to Next.js
- clarify that unit tests are not yet configured

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684418fb6150832b9984884f2380f7d6