### PR TITLE
Add unit tests and test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.0.4",

--- a/src/hooks/use-toast.test.ts
+++ b/src/hooks/use-toast.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { reducer } from './use-toast'
+
+const baseToast = { id: '1', open: true } as any
+
+/** utility to deep clone object */
+function clone<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj))
+}
+
+test('ADD_TOAST adds a toast', () => {
+  const state = { toasts: [] as any[] }
+  const result = reducer(state, { type: 'ADD_TOAST', toast: baseToast })
+  assert.deepEqual(result.toasts, [baseToast])
+})
+
+test('UPDATE_TOAST updates existing toast', () => {
+  const state = { toasts: [clone(baseToast)] }
+  const result = reducer(state, { type: 'UPDATE_TOAST', toast: { id: '1', title: 'new' } })
+  assert.equal(result.toasts[0].title, 'new')
+})
+
+
+test('REMOVE_TOAST removes a toast', () => {
+  const state = { toasts: [clone(baseToast), { id: '2' } as any] }
+  const result = reducer(state, { type: 'REMOVE_TOAST', toastId: '1' })
+  assert.equal(result.toasts.length, 1)
+  assert.equal(result.toasts[0].id, '2')
+})

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,11 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { cn } from './utils'
+
+test('cn merges class names using tailwind-merge', () => {
+  assert.equal(cn('p-2', 'p-4'), 'p-4')
+})
+
+test('cn skips falsey values', () => {
+  assert.equal(cn('a', undefined, 'b'), 'a b')
+})


### PR DESCRIPTION
## Summary
- add initial Node-based unit tests
- configure `npm run test` to run the tests via `tsx`

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6844256d751c832bbcb4f8daa23f0601