### PR TITLE
Add goal handler with unit tests

### DIFF
--- a/src/models/GoalHandler.test.ts
+++ b/src/models/GoalHandler.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { Goal } from './Goal'
+import { GoalHandler } from './GoalHandler'
+import { Status } from '@/types/Status'
+import { AOL } from '@/types/AOL'
+
+function createSampleGoal(id: number): Goal {
+  return new Goal(id, `goal${id}`, '', 0, 0, 1, [new Date(), new Date()], Status.NotStarted, AOL.Health)
+}
+
+test('createGoal adds a goal to the handler', () => {
+  const handler = new GoalHandler()
+  const goal = createSampleGoal(1)
+  handler.createGoal(goal)
+  assert.equal(handler.getGoals().length, 1)
+  assert.equal(handler.getGoals()[0].id, 1)
+})
+
+test('deleteGoal removes the specified goal', () => {
+  const handler = new GoalHandler()
+  handler.createGoal(createSampleGoal(1))
+  handler.createGoal(createSampleGoal(2))
+  handler.deleteGoal(1)
+  assert.equal(handler.getGoals().length, 1)
+  assert.equal(handler.getGoals()[0].id, 2)
+})

--- a/src/models/GoalHandler.ts
+++ b/src/models/GoalHandler.ts
@@ -1,0 +1,31 @@
+import { Goal } from "@/models/Goal"
+
+/**
+ * GoalHandler manages a collection of goals.
+ */
+export class GoalHandler {
+  private goals: Goal[] = []
+
+  /**
+   * Adds a new goal to the handler.
+   * @param goal Goal instance to store
+   */
+  createGoal(goal: Goal): void {
+    this.goals.push(goal)
+  }
+
+  /**
+   * Removes a goal by id.
+   * @param id Identifier of the goal to delete
+   */
+  deleteGoal(id: number): void {
+    this.goals = this.goals.filter((g) => g.id !== id)
+  }
+
+  /**
+   * Returns all stored goals.
+   */
+  getGoals(): Goal[] {
+    return this.goals
+  }
+}


### PR DESCRIPTION
## Summary
- add `GoalHandler` class to manage goals in memory
- cover basic goal handler functionality with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68442b74cca0832bb63eb3a2fbaf12c9