### PR TITLE
Add goal creation modal

### DIFF
--- a/src/components/pages/GoalPage.tsx
+++ b/src/components/pages/GoalPage.tsx
@@ -26,7 +26,7 @@ export default function GoalPage() {
             <h2 className="text-2xl font-bold">Goals</h2>
             <button
               onClick={() => setShowAdd(true)}
-              className="flex items-center bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded shadow"
+              className="flex items-center justify-center w-full sm:w-auto bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-lg shadow transition duration-150 ease-in-out"
             >
               <Plus size={18} className="mr-2" /> Add Goal
             </button>

--- a/src/components/pages/GoalPage.tsx
+++ b/src/components/pages/GoalPage.tsx
@@ -3,12 +3,16 @@ import { useState } from 'react';
 import ClientDetailView from '../ClientDetailView';
 import { GoalHandler } from '@/models/GoalHandler';
 import { containerStyle, statusLabelStyle } from '@/styles/statusStyles';
+import { Plus } from 'lucide-react';
+import AddGoalModal from '@/modal/AddGoalModal';
 
 
 export default function GoalPage() {
   const [selectedGoal, setSelectedGoal] = useState<Goal | null>(null);
-
-  const goals = GoalHandler.getInstance().getGoals();
+  const [goals, setGoals] = useState<Goal[]>(
+    GoalHandler.getInstance().getGoals(),
+  );
+  const [showAdd, setShowAdd] = useState(false);
 
   return (
     <section className="mb-6 p-4 sm:p-6 rounded-lg shadow border bg-white">
@@ -18,13 +22,21 @@ export default function GoalPage() {
           onBack={() => setSelectedGoal(null)} onSaveChanges={undefined} onDeleteClient={undefined} />
       ) : (
         <>
-          <h2 className="text-2xl font-bold mb-4">Goals</h2>
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-2xl font-bold">Goals</h2>
+            <button
+              onClick={() => setShowAdd(true)}
+              className="flex items-center bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded shadow"
+            >
+              <Plus size={18} className="mr-2" /> Add Goal
+            </button>
+          </div>
           <ul className="space-y-4">
             {goals.map((goal) => (
               <li
                 key={goal.id}
-                className={`${containerStyle[goal.status]} p-3 border rounded-md flex flex-col 
-                          sm:flex-row justify-between items-start sm:items-center 
+                className={`${containerStyle[goal.status]} p-3 border rounded-md flex flex-col
+                          sm:flex-row justify-between items-start sm:items-center
                           gap-2 cursor-pointer transition-shadow hover:shadow-md `}
                 onClick={() => setSelectedGoal(goal)}
               >
@@ -43,6 +55,11 @@ export default function GoalPage() {
           </ul>
         </>
       )}
+      <AddGoalModal
+        isOpen={showAdd}
+        onClose={() => setShowAdd(false)}
+        onCreated={() => setGoals(GoalHandler.getInstance().getGoals())}
+      />
     </section>
   );
 }

--- a/src/modal/AddGoalModal.tsx
+++ b/src/modal/AddGoalModal.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import Modal from '@/components/Modal';
+import { Goal } from '@/models/Goal';
+import { GoalHandler } from '@/models/GoalHandler';
+import { Status } from '@/types/Status';
+import { AOL } from '@/types/AOL';
+
+interface AddGoalModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+export default function AddGoalModal({ isOpen, onClose, onCreated }: AddGoalModalProps) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [start, setStart] = useState(0);
+  const [stand, setStand] = useState(0);
+  const [objective, setObjective] = useState(0);
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [status, setStatus] = useState<Status>(Status.NOT_STARTED);
+  const [aol, setAol] = useState<AOL>(AOL.GROWTH);
+
+  const handleCreate = () => {
+    const goal = new Goal(
+      Date.now(),
+      name,
+      description,
+      start,
+      stand,
+      objective,
+      [new Date(startDate), new Date(endDate)],
+      status,
+      aol
+    );
+    GoalHandler.getInstance().createGoal(goal);
+    if (onCreated) onCreated();
+    onClose();
+    // reset fields
+    setName('');
+    setDescription('');
+    setStart(0);
+    setStand(0);
+    setObjective(0);
+    setStartDate('');
+    setEndDate('');
+    setStatus(Status.NOT_STARTED);
+    setAol(AOL.GROWTH);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Add Goal">
+      <div className="space-y-3">
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full p-2 border border-gray-300 rounded"
+        />
+        <textarea
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full p-2 border border-gray-300 rounded"
+        />
+        <div className="grid grid-cols-3 gap-2">
+          <input
+            type="number"
+            placeholder="Start"
+            value={start}
+            onChange={(e) => setStart(Number(e.target.value))}
+            className="p-2 border border-gray-300 rounded"
+          />
+          <input
+            type="number"
+            placeholder="Current"
+            value={stand}
+            onChange={(e) => setStand(Number(e.target.value))}
+            className="p-2 border border-gray-300 rounded"
+          />
+          <input
+            type="number"
+            placeholder="Objective"
+            value={objective}
+            onChange={(e) => setObjective(Number(e.target.value))}
+            className="p-2 border border-gray-300 rounded"
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="p-2 border border-gray-300 rounded"
+          />
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="p-2 border border-gray-300 rounded"
+          />
+        </div>
+        <select
+          value={status}
+          onChange={(e) => setStatus(e.target.value as Status)}
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          {Object.values(Status).map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <select
+          value={aol}
+          onChange={(e) => setAol(e.target.value as AOL)}
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          {Object.values(AOL).map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+        <div className="flex justify-end pt-2">
+          <button
+            onClick={handleCreate}
+            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+          >
+            Create Goal
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/modal/AddGoalModal.tsx
+++ b/src/modal/AddGoalModal.tsx
@@ -17,8 +17,15 @@ export default function AddGoalModal({ isOpen, onClose, onCreated }: AddGoalModa
   const [start, setStart] = useState(0);
   const [stand, setStand] = useState(0);
   const [objective, setObjective] = useState(0);
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
+  const [startDate, setStartDate] = useState(() => {
+    const today = new Date();
+    return today.toISOString().slice(0, 10);
+  });
+  const [endDate, setEndDate] = useState(() => {
+    const nextYear = new Date();
+    nextYear.setFullYear(nextYear.getFullYear() + 1);
+    return nextYear.toISOString().slice(0, 10);
+  });
   const [status, setStatus] = useState<Status>(Status.NOT_STARTED);
   const [aol, setAol] = useState<AOL>(AOL.GROWTH);
 
@@ -43,87 +50,113 @@ export default function AddGoalModal({ isOpen, onClose, onCreated }: AddGoalModa
     setStart(0);
     setStand(0);
     setObjective(0);
-    setStartDate('');
-    setEndDate('');
+    const today = new Date().toISOString().slice(0, 10);
+    const nextYear = new Date();
+    nextYear.setFullYear(nextYear.getFullYear() + 1);
+    const yearLater = nextYear.toISOString().slice(0, 10);
+    setStartDate(today);
+    setEndDate(yearLater);
     setStatus(Status.NOT_STARTED);
     setAol(AOL.GROWTH);
   };
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Add Goal">
-      <div className="space-y-3">
-        <input
-          type="text"
-          placeholder="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          className="w-full p-2 border border-gray-300 rounded"
-        />
-        <textarea
-          placeholder="Description"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          className="w-full p-2 border border-gray-300 rounded"
-        />
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full p-2 border border-gray-300 rounded"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="w-full p-2 border border-gray-300 rounded"
+          />
+        </div>
         <div className="grid grid-cols-3 gap-2">
-          <input
-            type="number"
-            placeholder="Start"
-            value={start}
-            onChange={(e) => setStart(Number(e.target.value))}
-            className="p-2 border border-gray-300 rounded"
-          />
-          <input
-            type="number"
-            placeholder="Current"
-            value={stand}
-            onChange={(e) => setStand(Number(e.target.value))}
-            className="p-2 border border-gray-300 rounded"
-          />
-          <input
-            type="number"
-            placeholder="Objective"
-            value={objective}
-            onChange={(e) => setObjective(Number(e.target.value))}
-            className="p-2 border border-gray-300 rounded"
-          />
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Start</label>
+            <input
+              type="number"
+              value={start}
+              onChange={(e) => setStart(Number(e.target.value))}
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Current</label>
+            <input
+              type="number"
+              value={stand}
+              onChange={(e) => setStand(Number(e.target.value))}
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Objective</label>
+            <input
+              type="number"
+              value={objective}
+              onChange={(e) => setObjective(Number(e.target.value))}
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+          </div>
         </div>
         <div className="grid grid-cols-2 gap-2">
-          <input
-            type="date"
-            value={startDate}
-            onChange={(e) => setStartDate(e.target.value)}
-            className="p-2 border border-gray-300 rounded"
-          />
-          <input
-            type="date"
-            value={endDate}
-            onChange={(e) => setEndDate(e.target.value)}
-            className="p-2 border border-gray-300 rounded"
-          />
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Start Date</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">End Date</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+          </div>
         </div>
-        <select
-          value={status}
-          onChange={(e) => setStatus(e.target.value as Status)}
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          {Object.values(Status).map((s) => (
-            <option key={s} value={s}>
-              {s}
-            </option>
-          ))}
-        </select>
-        <select
-          value={aol}
-          onChange={(e) => setAol(e.target.value as AOL)}
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          {Object.values(AOL).map((o) => (
-            <option key={o} value={o}>
-              {o}
-            </option>
-          ))}
-        </select>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+          <select
+            value={status}
+            onChange={(e) => setStatus(e.target.value as Status)}
+            className="w-full p-2 border border-gray-300 rounded"
+          >
+            {Object.values(Status).map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Area of Life</label>
+          <select
+            value={aol}
+            onChange={(e) => setAol(e.target.value as AOL)}
+            className="w-full p-2 border border-gray-300 rounded"
+          >
+            {Object.values(AOL).map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+        </div>
         <div className="flex justify-end pt-2">
           <button
             onClick={handleCreate}


### PR DESCRIPTION
## Summary
- implement AddGoalModal for creating new goals
- wire modal into GoalPage with "Add Goal" button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68444a116200832ba38aabe676160378