### PR TITLE
Seed data now lives on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ LifeManager accelerates personal goal attainment by turning a high-level aspirat
 ## Development Workflow
 1. Install dependencies with `npm install`.
 2. Run the backend server using `npm run server` and keep it running.
+   Verify it is reachable with `curl http://localhost:3001/goals`.
 3. In another terminal start the dev server with `npm run dev`.
 4. Lint with `npm run lint`.
 5. Build production assets with `npm run build`.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ LifeManager accelerates personal goal attainment by turning a high-level aspirat
 - CI/CD: GitHub Actions, codecov
 ## Development Workflow
 1. Install dependencies with `npm install`.
-2. Start the dev server using `npm run dev`.
-3. Lint with `npm run lint`.
-4. Build production assets with `npm run build`.
+2. Run the backend server using `npm run server` and keep it running.
+3. In another terminal start the dev server with `npm run dev`.
+4. Lint with `npm run lint`.
+5. Build production assets with `npm run build`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nextn",
+  "name": "lifemanager",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextn",
+      "name": "lifemanager",
       "version": "0.1.0",
       "dependencies": {
         "@genkit-ai/googleai": "^1.0.4",
@@ -54,6 +54,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "concurrently": "^9.1.2",
         "eslint": "^9.28.0",
         "eslint-config-next": "^15.3.3",
         "genkit-cli": "^1.0.4",
@@ -6344,6 +6345,48 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/concurrently": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.1.2.tgz",
+      "integrity": "sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -12019,6 +12062,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
@@ -12816,6 +12872,16 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/triple-beam": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test"
+    "test": "tsx --test",
+    "server": "tsx src/server/server.ts"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p 9002",
+    "dev": "concurrently \"tsx src/server/server.ts\" \"next dev --turbopack -p 9002\"",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "next build",
@@ -60,6 +60,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "concurrently": "^9.1.2",
     "eslint": "^9.28.0",
     "eslint-config-next": "^15.3.3",
     "genkit-cli": "^1.0.4",

--- a/src/components/pages/GoalPage.tsx
+++ b/src/components/pages/GoalPage.tsx
@@ -1,5 +1,5 @@
 import { Goal } from '@/models/Goal';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ClientDetailView from '../ClientDetailView';
 import { GoalHandler } from '@/models/GoalHandler';
 import { containerStyle, statusLabelStyle } from '@/styles/statusStyles';
@@ -9,9 +9,13 @@ import AddGoalModal from '@/modal/AddGoalModal';
 
 export default function GoalPage() {
   const [selectedGoal, setSelectedGoal] = useState<Goal | null>(null);
-  const [goals, setGoals] = useState<Goal[]>(
-    GoalHandler.getInstance().getGoals(),
-  );
+  const [goals, setGoals] = useState<Goal[]>([]);
+  useEffect(() => {
+    GoalHandler.getInstance()
+      .getGoals()
+      .then(setGoals)
+      .catch(() => setGoals([]));
+  }, []);
   const [showAdd, setShowAdd] = useState(false);
 
   return (
@@ -58,7 +62,10 @@ export default function GoalPage() {
       <AddGoalModal
         isOpen={showAdd}
         onClose={() => setShowAdd(false)}
-        onCreated={() => setGoals(GoalHandler.getInstance().getGoals())}
+        onCreated={async () => {
+          const updated = await GoalHandler.getInstance().getGoals();
+          setGoals(updated);
+        }}
       />
     </section>
   );

--- a/src/components/pages/ProjectPage.tsx
+++ b/src/components/pages/ProjectPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Plus, Search } from "lucide-react";
 import { ProjectHandler } from "@/models/ProjectHandler";
 import { containerStyle, statusLabelStyle } from "@/styles/statusStyles";
@@ -7,9 +7,13 @@ import AddProjectModal from "@/modal/AddProjectModal";
 
 /* ---------- main component ---------- */
 export default function ProjectPage() {
-  const [projects, setProjects] = useState(
-    ProjectHandler.getInstance().getProjects()
-  );
+  const [projects, setProjects] = useState<any[]>([]);
+  useEffect(() => {
+    ProjectHandler.getInstance()
+      .getProjects()
+      .then(setProjects)
+      .catch(() => setProjects([]));
+  }, []);
   const [showAdd, setShowAdd] = useState(false);
   const [search, setSearch] = useState("");
 
@@ -65,9 +69,10 @@ export default function ProjectPage() {
       <AddProjectModal
         isOpen={showAdd}
         onClose={() => setShowAdd(false)}
-        onCreated={() =>
-          setProjects(ProjectHandler.getInstance().getProjects())
-        }
+        onCreated={async () => {
+          const updated = await ProjectHandler.getInstance().getProjects();
+          setProjects(updated);
+        }}
       />
     </section>
   );

--- a/src/modal/AddGoalModal.tsx
+++ b/src/modal/AddGoalModal.tsx
@@ -29,7 +29,7 @@ export default function AddGoalModal({ isOpen, onClose, onCreated }: AddGoalModa
   const [status, setStatus] = useState<Status>(Status.NOT_STARTED);
   const [aol, setAol] = useState<AOL>(AOL.GROWTH);
 
-  const handleCreate = () => {
+  const handleCreate = async () => {
     const goal = new Goal(
       Date.now(),
       name,
@@ -41,8 +41,8 @@ export default function AddGoalModal({ isOpen, onClose, onCreated }: AddGoalModa
       status,
       aol
     );
-    GoalHandler.getInstance().createGoal(goal);
-    if (onCreated) onCreated();
+    await GoalHandler.getInstance().createGoal(goal);
+    if (onCreated) await onCreated();
     onClose();
     // reset fields
     setName('');

--- a/src/models/GoalHandler.test.ts
+++ b/src/models/GoalHandler.test.ts
@@ -50,3 +50,17 @@ test('deleteGoal removes the specified goal', async () => {
   assert.equal(goals[0].id, 2)
   server.close()
 })
+
+test('getGoals converts period to Date objects', async () => {
+  const server = createServer()
+  await new Promise(resolve => server.listen(0, resolve))
+  const { port } = server.address() as any
+  GoalHandler.reset()
+  const handler = GoalHandler.getInstance(`http://localhost:${port}`)
+  await handler.clearGoals()
+  await handler.createGoal(createSampleGoal(1))
+  const goals = await handler.getGoals()
+  assert.ok(goals[0].period[0] instanceof Date)
+  assert.ok(goals[0].period[1] instanceof Date)
+  server.close()
+})

--- a/src/models/GoalHandler.ts
+++ b/src/models/GoalHandler.ts
@@ -67,6 +67,20 @@ export class GoalHandler {
    */
   async getGoals(): Promise<Goal[]> {
     const res = await fetch(`${this.baseUrl}/goals`)
-    return res.json()
+    const data = await res.json()
+    return data.map(
+      (g: any) =>
+        new Goal(
+          g.id,
+          g.name,
+          g.description,
+          g.start,
+          g.stand,
+          g.objective,
+          [new Date(g.period[0]), new Date(g.period[1])],
+          g.status,
+          g.aol
+        )
+    )
   }
 }

--- a/src/models/GoalHandler.ts
+++ b/src/models/GoalHandler.ts
@@ -1,94 +1,72 @@
 import { Goal } from "@/models/Goal"
-import { Status } from "@/types/Status"
-import { AOL } from "@/types/AOL"
 
 /**
- * GoalHandler manages a collection of goals.
+ * GoalHandler manages goals persisted on the backend server.
  */
 export class GoalHandler {
   private static instance: GoalHandler | null = null
 
-  private goals: Goal[] = []
+  private baseUrl: string
 
-  private constructor() {
-    this.goals = [
-      new Goal(
-        1,
-        'Projektplanung abschließen',
-        'Detaillierte Schritte und Meilensteine festlegen',
-        0,
-        20,
-        100,
-        [new Date('2025-06-01'), new Date('2025-09-30')],
-        Status.ON_TRACK,
-        AOL.PURPOSE
-      ),
-      new Goal(
-        2,
-        'MVP-Implementierung starten',
-        'Kernfunktionalität entwickeln und testen',
-        0,
-        10,
-        100,
-        [new Date('2025-06-15'), new Date('2025-10-15')],
-        Status.AT_RISK,
-        AOL.GROWTH
-      ),
-      new Goal(
-        3,
-        'Markteinführung vorbereiten',
-        'Marketing-Kampagne und Dokumentation erstellen',
-        0,
-        0,
-        100,
-        [new Date('2025-07-01'), new Date('2025-11-01')],
-        Status.OFF_TRACK,
-        AOL.FINANCES
-      ),
-    ]
+  private constructor(baseUrl: string) {
+    this.baseUrl = baseUrl
   }
 
-  static getInstance(): GoalHandler {
+  static getInstance(baseUrl = 'http://localhost:3001'): GoalHandler {
     if (!GoalHandler.instance) {
-      GoalHandler.instance = new GoalHandler()
+      GoalHandler.instance = new GoalHandler(baseUrl)
     }
     return GoalHandler.instance
+  }
+
+  /** Reset the singleton instance (primarily for tests). */
+  static reset(): void {
+    GoalHandler.instance = null
   }
 
   /**
    * Adds a new goal to the handler.
    * @param goal Goal instance to store
    */
-  createGoal(goal: Goal): void {
-    this.goals.push(goal)
+  async createGoal(goal: Goal): Promise<void> {
+    await fetch(`${this.baseUrl}/goals`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(goal),
+    })
   }
 
   /**
    * Removes a goal by id.
    * @param id Identifier of the goal to delete
    */
-  deleteGoal(id: number): void {
-    this.goals = this.goals.filter((g) => g.id !== id)
+  async deleteGoal(id: number): Promise<void> {
+    await fetch(`${this.baseUrl}/goals/${id}`, { method: 'DELETE' })
   }
 
   /**
    * Removes all goals from the handler. Primarily used for tests.
    */
-  clearGoals(): void {
-    this.goals = []
+  async clearGoals(): Promise<void> {
+    await fetch(`${this.baseUrl}/admin/clearGoals`, { method: 'POST' })
   }
 
   /**
    * Replace all goals with the provided list. Useful for testing.
    */
-  setGoals(goals: Goal[]): void {
-    this.goals = goals
+  async setGoals(goals: Goal[]): Promise<void> {
+    await fetch(`${this.baseUrl}/admin/setGoals`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(goals),
+    })
   }
 
   /**
    * Returns all stored goals.
    */
-  getGoals(): Goal[] {
-    return this.goals
+  async getGoals(): Promise<Goal[]> {
+    const res = await fetch(`${this.baseUrl}/goals`)
+    return res.json()
   }
 }

--- a/src/models/ProjectHandler.test.ts
+++ b/src/models/ProjectHandler.test.ts
@@ -77,3 +77,22 @@ test('getProjectsForGoal filters correctly', async () => {
   assert.ok(filtered.every((p) => p.goal.id === 1))
   server.close()
 })
+
+test('getProjects returns projects with date objects', async () => {
+  const server = createServer()
+  await new Promise(resolve => server.listen(0, resolve))
+  const { port } = server.address() as any
+  GoalHandler.reset()
+  ProjectHandler.reset()
+  const goalHandler = GoalHandler.getInstance(`http://localhost:${port}`)
+  const projectHandler = ProjectHandler.getInstance(goalHandler, `http://localhost:${port}`)
+  await goalHandler.clearGoals()
+  await projectHandler.clearProjects()
+  const goal = createGoal(1)
+  await goalHandler.createGoal(goal)
+  await projectHandler.createProject(createProject(1, goal))
+  const projects = await projectHandler.getProjects()
+  assert.ok(projects[0].period[0] instanceof Date)
+  assert.ok(projects[0].goal.period[0] instanceof Date)
+  server.close()
+})

--- a/src/models/ProjectHandler.test.ts
+++ b/src/models/ProjectHandler.test.ts
@@ -6,6 +6,7 @@ import { Goal } from './Goal'
 import { Project } from './Project'
 import { Status } from '@/types/Status'
 import { AOL } from '@/types/AOL'
+import { createServer } from '../server/server'
 
 function createGoal(id: number): Goal {
   return new Goal(id, `g${id}`, '', 0, 0, 1, [new Date(), new Date()], Status.NOT_STARTED, AOL.GROWTH)
@@ -15,50 +16,64 @@ function createProject(id: number, goal: Goal): Project {
   return new Project(id, `p${id}`, '', 0, 0, 1, [new Date(), new Date()], Status.NOT_STARTED, goal)
 }
 
-test('createProject adds a project', () => {
-  const goalHandler = GoalHandler.getInstance()
-  goalHandler.clearGoals()
+test('createProject adds a project', async () => {
+  const server = createServer()
+  await new Promise(resolve => server.listen(0, resolve))
+  const { port } = server.address() as any
+  GoalHandler.reset()
+  ProjectHandler.reset()
+  const goalHandler = GoalHandler.getInstance(`http://localhost:${port}`)
+  const projectHandler = ProjectHandler.getInstance(goalHandler, `http://localhost:${port}`)
+  await goalHandler.clearGoals()
+  await projectHandler.clearProjects()
   const goal = createGoal(1)
-  goalHandler.createGoal(goal)
-
-  const projectHandler = ProjectHandler.getInstance(goalHandler)
-  projectHandler.clearProjects()
-  projectHandler.createProject(createProject(1, goal))
-
-  assert.equal(projectHandler.getProjects().length, 1)
-  assert.equal(projectHandler.getProjects()[0].id, 1)
+  await goalHandler.createGoal(goal)
+  await projectHandler.createProject(createProject(1, goal))
+  const projects = await projectHandler.getProjects()
+  assert.equal(projects.length, 1)
+  assert.equal(projects[0].id, 1)
+  server.close()
 })
 
-test('deleteProject removes the specified project', () => {
-  const goalHandler = GoalHandler.getInstance()
-  goalHandler.clearGoals()
+test('deleteProject removes the specified project', async () => {
+  const server = createServer()
+  await new Promise(resolve => server.listen(0, resolve))
+  const { port } = server.address() as any
+  GoalHandler.reset()
+  ProjectHandler.reset()
+  const goalHandler = GoalHandler.getInstance(`http://localhost:${port}`)
+  const projectHandler = ProjectHandler.getInstance(goalHandler, `http://localhost:${port}`)
+  await goalHandler.clearGoals()
+  await projectHandler.clearProjects()
   const goal = createGoal(1)
-  goalHandler.createGoal(goal)
-
-  const projectHandler = ProjectHandler.getInstance(goalHandler)
-  projectHandler.clearProjects()
-  projectHandler.createProject(createProject(1, goal))
-  projectHandler.createProject(createProject(2, goal))
-
-  projectHandler.deleteProject(1)
-  assert.equal(projectHandler.getProjects().length, 1)
-  assert.equal(projectHandler.getProjects()[0].id, 2)
+  await goalHandler.createGoal(goal)
+  await projectHandler.createProject(createProject(1, goal))
+  await projectHandler.createProject(createProject(2, goal))
+  await projectHandler.deleteProject(1)
+  const projects = await projectHandler.getProjects()
+  assert.equal(projects.length, 1)
+  assert.equal(projects[0].id, 2)
+  server.close()
 })
 
-test('getProjectsForGoal filters correctly', () => {
-  const goalHandler = GoalHandler.getInstance()
-  goalHandler.clearGoals()
+test('getProjectsForGoal filters correctly', async () => {
+  const server = createServer()
+  await new Promise(resolve => server.listen(0, resolve))
+  const { port } = server.address() as any
+  GoalHandler.reset()
+  ProjectHandler.reset()
+  const goalHandler = GoalHandler.getInstance(`http://localhost:${port}`)
+  const projectHandler = ProjectHandler.getInstance(goalHandler, `http://localhost:${port}`)
+  await goalHandler.clearGoals()
+  await projectHandler.clearProjects()
   const goal1 = createGoal(1)
   const goal2 = createGoal(2)
-  goalHandler.setGoals([goal1, goal2])
-
-  const projectHandler = ProjectHandler.getInstance(goalHandler)
-  projectHandler.clearProjects()
-  projectHandler.createProject(createProject(1, goal1))
-  projectHandler.createProject(createProject(2, goal2))
-  projectHandler.createProject(createProject(3, goal1))
-
-  const filtered = projectHandler.getProjectsForGoal(1)
+  await goalHandler.setGoals([goal1, goal2])
+  await projectHandler.createProject(createProject(1, goal1))
+  await projectHandler.createProject(createProject(2, goal2))
+  await projectHandler.createProject(createProject(3, goal1))
+  const filtered = await projectHandler.getProjectsForGoal(1)
   assert.equal(filtered.length, 2)
   assert.ok(filtered.every((p) => p.goal.id === 1))
+  server.close()
 })

--- a/src/models/ProjectHandler.ts
+++ b/src/models/ProjectHandler.ts
@@ -1,4 +1,5 @@
 import { Project } from './Project'
+import { Goal } from './Goal'
 import { GoalHandler } from './GoalHandler'
 
 /**
@@ -65,12 +66,60 @@ export class ProjectHandler {
   /** Get all stored projects. */
   async getProjects(): Promise<Project[]> {
     const res = await fetch(`${this.baseUrl}/projects`)
-    return res.json()
+    const data = await res.json()
+    return data.map(
+      (p: any) =>
+        new Project(
+          p.id,
+          p.name,
+          p.description,
+          p.start,
+          p.stand,
+          p.objective,
+          [new Date(p.period[0]), new Date(p.period[1])],
+          p.status,
+          new Goal(
+            p.goal.id,
+            p.goal.name,
+            p.goal.description,
+            p.goal.start,
+            p.goal.stand,
+            p.goal.objective,
+            [new Date(p.goal.period[0]), new Date(p.goal.period[1])],
+            p.goal.status,
+            p.goal.aol
+          )
+        )
+    )
   }
 
   /** Get projects associated with a specific goal id. */
   async getProjectsForGoal(goalId: number): Promise<Project[]> {
     const res = await fetch(`${this.baseUrl}/projects?goalId=${goalId}`)
-    return res.json()
+    const data = await res.json()
+    return data.map(
+      (p: any) =>
+        new Project(
+          p.id,
+          p.name,
+          p.description,
+          p.start,
+          p.stand,
+          p.objective,
+          [new Date(p.period[0]), new Date(p.period[1])],
+          p.status,
+          new Goal(
+            p.goal.id,
+            p.goal.name,
+            p.goal.description,
+            p.goal.start,
+            p.goal.stand,
+            p.goal.objective,
+            [new Date(p.goal.period[0]), new Date(p.goal.period[1])],
+            p.goal.status,
+            p.goal.aol
+          )
+        )
+    )
   }
 }

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -50,3 +50,19 @@ test('DELETE /goals removes a goal', async () => {
   const resDel = await request('DELETE', '/goals/100')
   assert.equal(resDel.status, 204)
 })
+
+test('server responds to curl', async () => {
+  const server = createServer()
+  await new Promise(resolve => server.listen(0, resolve))
+  const { port } = server.address() as any
+  const { exec } = await import('node:child_process')
+  const output: string = await new Promise((resolve, reject) => {
+    exec(`curl -s http://localhost:${port}/goals`, (err, stdout) => {
+      if (err) reject(err)
+      else resolve(stdout)
+    })
+  })
+  const data = JSON.parse(output)
+  assert.ok(Array.isArray(data))
+  server.close()
+})

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -51,6 +51,67 @@ test('DELETE /goals removes a goal', async () => {
   assert.equal(resDel.status, 204)
 })
 
+test('GET /projects returns initial projects', async () => {
+  const res = await request('GET', '/projects')
+  assert.equal(res.status, 200)
+  assert.ok(Array.isArray(res.data))
+})
+
+test('POST /projects creates a project', async () => {
+  const newProject = {
+    id: 55,
+    name: 'p',
+    description: '',
+    start: 0,
+    stand: 0,
+    objective: 1,
+    period: [new Date(), new Date()],
+    status: 'Not Started',
+    goal: {
+      id: 1,
+      name: 'g',
+      description: '',
+      start: 0,
+      stand: 0,
+      objective: 1,
+      period: [new Date(), new Date()],
+      status: 'Not Started',
+      aol: 'Growth'
+    }
+  }
+  const res = await request('POST', '/projects', JSON.stringify(newProject))
+  assert.equal(res.status, 201)
+  assert.equal(res.data.id, 55)
+})
+
+test('DELETE /projects removes a project', async () => {
+  const proj = {
+    id: 56,
+    name: 'tmp',
+    description: '',
+    start: 0,
+    stand: 0,
+    objective: 1,
+    period: [new Date(), new Date()],
+    status: 'Not Started',
+    goal: {
+      id: 1,
+      name: 'g',
+      description: '',
+      start: 0,
+      stand: 0,
+      objective: 1,
+      period: [new Date(), new Date()],
+      status: 'Not Started',
+      aol: 'Growth'
+    }
+  }
+  const resCreate = await request('POST', '/projects', JSON.stringify(proj))
+  assert.equal(resCreate.status, 201)
+  const resDel = await request('DELETE', '/projects/56')
+  assert.equal(resDel.status, 204)
+})
+
 test('server responds to curl', async () => {
   const server = createServer()
   await new Promise(resolve => server.listen(0, resolve))

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import { createServer } from './server'
+
+function request(method: string, path: string, body = ''): Promise<{ status: number; data: any }> {
+  const server = createServer()
+  return new Promise((resolve, reject) => {
+    server.listen(0, () => {
+      const { port } = server.address() as any
+      const options = { method, port, path }
+      const req = http.request(options, res => {
+        let data = ''
+        res.on('data', chunk => (data += chunk))
+        res.on('end', () => {
+          server.close()
+          const text = data || 'null'
+          resolve({ status: res.statusCode || 0, data: JSON.parse(text) })
+        })
+      })
+      req.on('error', err => {
+        server.close()
+        reject(err)
+      })
+      if (body) {
+        req.write(body)
+      }
+      req.end()
+    })
+  })
+}
+
+test('GET /goals returns initial goals', async () => {
+  const res = await request('GET', '/goals')
+  assert.equal(res.status, 200)
+  assert.ok(Array.isArray(res.data))
+  assert.ok(res.data.length >= 1)
+})
+
+test('POST /goals creates a goal', async () => {
+  const newGoal = { id: 99, name: 'new', description: '', start: 0, stand: 0, objective: 1, period: [new Date(), new Date()], status: 'Not Started', aol: 'Growth' }
+  const res = await request('POST', '/goals', JSON.stringify(newGoal))
+  assert.equal(res.status, 201)
+  assert.equal(res.data.id, 99)
+})
+
+test('DELETE /goals removes a goal', async () => {
+  const resCreate = await request('POST', '/goals', JSON.stringify({ id: 100, name: 'temp', description: '', start: 0, stand: 0, objective: 1, period: [new Date(), new Date()], status: 'Not Started', aol: 'Growth' }))
+  assert.equal(resCreate.status, 201)
+  const resDel = await request('DELETE', '/goals/100')
+  assert.equal(resDel.status, 204)
+})

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -169,3 +169,12 @@ export function createServer() {
     res.end('Not Found')
   })
 }
+
+// When executed directly via `npm run server`, start the HTTP server.
+if (require.main === module) {
+  const port = process.env.PORT ? Number(process.env.PORT) : 3001
+  createServer().listen(port, () => {
+    /* eslint-disable no-console */
+    console.log(`Server running on http://localhost:${port}`)
+  })
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,0 +1,171 @@
+import http from 'node:http'
+import { Goal } from '../models/Goal'
+import { Project } from '../models/Project'
+import { Status } from '../types/Status'
+import { AOL } from '../types/AOL'
+
+let goals: Goal[] = []
+let projects: Project[] = []
+
+function initData() {
+  goals = [
+    new Goal(
+      1,
+      'Projektplanung abschließen',
+      'Detaillierte Schritte und Meilensteine festlegen',
+      0,
+      20,
+      100,
+      [new Date('2025-06-01'), new Date('2025-09-30')],
+      Status.ON_TRACK,
+      AOL.PURPOSE
+    ),
+    new Goal(
+      2,
+      'MVP-Implementierung starten',
+      'Kernfunktionalität entwickeln und testen',
+      0,
+      10,
+      100,
+      [new Date('2025-06-15'), new Date('2025-10-15')],
+      Status.AT_RISK,
+      AOL.GROWTH
+    ),
+    new Goal(
+      3,
+      'Markteinführung vorbereiten',
+      'Marketing-Kampagne und Dokumentation erstellen',
+      0,
+      0,
+      100,
+      [new Date('2025-07-01'), new Date('2025-11-01')],
+      Status.OFF_TRACK,
+      AOL.FINANCES
+    ),
+  ]
+
+  projects = [
+    new Project(
+      1,
+      'Solar Farm Expansion',
+      'Expand the regional solar farm to 150\u202FMW capacity to support grid stability and meet renewable\u2011energy targets.',
+      0,
+      30,
+      100,
+      [new Date('2025-01-01'), new Date('2025-12-31')],
+      Status.ON_TRACK,
+      goals[1] || goals[0]
+    ),
+    new Project(
+      2,
+      'ERP Roll\u2011out',
+      'Implement a company\u2011wide ERP solution to unify finance, supply\u2011chain, and HR operations across all business units.',
+      0,
+      70,
+      100,
+      [new Date('2024-06-01'), new Date('2025-06-30')],
+      Status.AT_RISK,
+      goals[0] || goals[1]
+    ),
+  ]
+}
+
+initData()
+
+function parseBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise(resolve => {
+    let body = ''
+    req.on('data', chunk => {
+      body += chunk
+    })
+    req.on('end', () => resolve(body))
+  })
+}
+
+export function createServer() {
+  return http.createServer(async (req, res) => {
+    const { method, url } = req
+    const parsed = new URL(url || '/', 'http://localhost')
+
+    if (method === 'GET' && parsed.pathname === '/goals') {
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify(goals))
+      return
+    }
+
+    if (method === 'POST' && parsed.pathname === '/goals') {
+      const body = await parseBody(req)
+      const goal = JSON.parse(body)
+      goals.push(goal)
+      res.statusCode = 201
+      res.end(JSON.stringify(goal))
+      return
+    }
+
+    if (method === 'DELETE' && parsed.pathname.startsWith('/goals/')) {
+      const id = Number(parsed.pathname.split('/')[2])
+      goals = goals.filter(g => g.id !== id)
+      res.statusCode = 204
+      res.end()
+      return
+    }
+
+    if (method === 'POST' && parsed.pathname === '/admin/clearGoals') {
+      goals = []
+      res.statusCode = 204
+      res.end()
+      return
+    }
+
+    if (method === 'POST' && parsed.pathname === '/admin/setGoals') {
+      const body = await parseBody(req)
+      goals = JSON.parse(body)
+      res.statusCode = 204
+      res.end()
+      return
+    }
+
+    if (method === 'GET' && parsed.pathname === '/projects') {
+      const goalId = parsed.searchParams.get('goalId')
+      const result = goalId ? projects.filter(p => p.goal.id === Number(goalId)) : projects
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify(result))
+      return
+    }
+
+    if (method === 'POST' && parsed.pathname === '/projects') {
+      const body = await parseBody(req)
+      const project = JSON.parse(body)
+      projects.push(project)
+      res.statusCode = 201
+      res.end(JSON.stringify(project))
+      return
+    }
+
+    if (method === 'DELETE' && parsed.pathname.startsWith('/projects/')) {
+      const id = Number(parsed.pathname.split('/')[2])
+      projects = projects.filter(p => p.id !== id)
+      res.statusCode = 204
+      res.end()
+      return
+    }
+
+    if (method === 'POST' && parsed.pathname === '/admin/clearProjects') {
+      projects = []
+      res.statusCode = 204
+      res.end()
+      return
+    }
+
+    if (method === 'POST' && parsed.pathname === '/admin/setProjects') {
+      const body = await parseBody(req)
+      projects = JSON.parse(body)
+      res.statusCode = 204
+      res.end()
+      return
+    }
+
+    res.statusCode = 404
+    res.end('Not Found')
+  })
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -85,6 +85,16 @@ function parseBody(req: http.IncomingMessage): Promise<string> {
 export function createServer() {
   return http.createServer(async (req, res) => {
     const { method, url } = req
+
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
+    if (method === 'OPTIONS') {
+      res.statusCode = 204
+      res.end()
+      return
+    }
     const parsed = new URL(url || '/', 'http://localhost')
 
     if (method === 'GET' && parsed.pathname === '/goals') {


### PR DESCRIPTION
## Summary
- move goal and project seed data to backend server
- fetch goals and projects via HTTP in GoalHandler and ProjectHandler
- update tests to start server and use async methods
- extend server to manage goals and projects through REST endpoints
- document how to run the new server

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68450d9e2050832b899a6355a4ce7dfe