### PR TITLE
Fix dev server font errors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,9 +78,10 @@ body {
 
 @layer base {
   * {
-    @apply border-border;
+    border-color: hsl(var(--border));
   }
   body {
-    @apply bg-background text-foreground;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,11 @@
 import type {Metadata} from 'next';
-import {Geist, Geist_Mono} from 'next/font/google';
+// Use basic system fonts to avoid runtime network fetches
+// Google fonts require internet access during build which is
+// unavailable in some environments.
+// import {Geist, Geist_Mono} from 'next/font/google';
 import './globals.css';
 import { AppShell } from '@/components/ui/app-shell';
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-});
 
 export const metadata: Metadata = {
   title: 'Lifemanager',
@@ -25,7 +19,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className="antialiased">
         <AppShell>{children}</AppShell>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- remove Google font imports from layout
- inline base colors in globals.css

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684565374660832b899fc614fa7d7c06