### PR TITLE
Add goal progress overview tab

### DIFF
--- a/src/components/tabs/goal/GoalOverviewTab.tsx
+++ b/src/components/tabs/goal/GoalOverviewTab.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Goal } from '@/models/Goal'
+import { Progress } from '@/components/ui/progress'
+
+interface GoalOverviewTabProps {
+  goal: Goal
+}
+
+const GoalOverviewTab: React.FC<GoalOverviewTabProps> = ({ goal }) => {
+  const progress = Math.round(goal.progressPercentage)
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm font-medium text-gray-700 mb-1">Progress</p>
+        <Progress value={progress} />
+        <p className="text-sm text-gray-600 mt-1">{progress}%</p>
+      </div>
+      <div className="text-sm text-gray-700 space-y-1">
+        <p>
+          <span className="font-medium">Start:</span> {goal.period[0].toLocaleDateString()}
+        </p>
+        <p>
+          <span className="font-medium">End:</span> {goal.period[1].toLocaleDateString()}
+        </p>
+        <p>
+          {goal.daysElapsed} days elapsed, {goal.daysRemaining} days remaining
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default GoalOverviewTab

--- a/src/components/views/GoalDetailView.tsx
+++ b/src/components/views/GoalDetailView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { User, Heart, Calendar, FileText, Trash2, Edit, ChartNoAxesCombined, ListTodo, LucideProps } from 'lucide-react';
 import Modal from '@/components/ui/modal';
-import OverviewTab from '../tabs/goal/OverviewTab';
+import GoalOverviewTab from '../tabs/goal/GoalOverviewTab';
 import ProjectTab from '../tabs/goal/ProjectTab';
 import TaskTab from '../tabs/goal/TaskTab';
 import DocumentTab from '../tabs/goal/DocumentTab';
@@ -50,7 +50,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({ goal }) => {
     const commonProps = { client: editedGoal, isEditing, onChange: handleInputChange };
     switch (activeTab) {
       case 'overview':
-        return <OverviewTab {...commonProps} onScopeChange={handleScopeChange} />;
+        return <GoalOverviewTab goal={editedGoal} />;
       case 'project':
         return <ProjectTab {...commonProps} />;
       case 'tasks':

--- a/src/models/Goal.ts
+++ b/src/models/Goal.ts
@@ -36,4 +36,32 @@ export class Goal {
         this.status = status;
         this.aol = aol;
     }
+
+    /**
+     * Percentage progress based on start, stand and objective values.
+     */
+    get progressPercentage(): number {
+        if (this.objective === this.start) return 0;
+        return ((this.stand - this.start) / (this.objective - this.start)) * 100;
+    }
+
+    /** Total number of days for the goal period. */
+    get totalDays(): number {
+        const ms = this.period[1].getTime() - this.period[0].getTime();
+        return Math.ceil(ms / (1000 * 60 * 60 * 24));
+    }
+
+    /** Days elapsed since the start of the goal. */
+    get daysElapsed(): number {
+        const now = new Date();
+        const ms = now.getTime() - this.period[0].getTime();
+        return Math.max(0, Math.floor(ms / (1000 * 60 * 60 * 24)));
+    }
+
+    /** Remaining days until the goal ends. */
+    get daysRemaining(): number {
+        const now = new Date();
+        const ms = this.period[1].getTime() - now.getTime();
+        return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)));
+    }
 }


### PR DESCRIPTION
## Summary
- compute progress and days information on `Goal`
- show a new `GoalOverviewTab` with progress and date info
- display the new tab from `GoalDetailView`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684586539bd0832bb2a0433dfcdb6e81