### PR TITLE
Add back navigation for goal details

### DIFF
--- a/src/components/pages/GoalPage.tsx
+++ b/src/components/pages/GoalPage.tsx
@@ -21,7 +21,7 @@ export default function GoalPage() {
   return (
     <section className="mb-6 p-4 sm:p-6 rounded-lg shadow border bg-white">
       {selectedGoal ? (
-        <GoalDetailView goal={selectedGoal} />
+        <GoalDetailView goal={selectedGoal} onBack={() => setSelectedGoal(null)} />
       ) : (
         <>
           <div className="flex justify-between items-center mb-4">

--- a/src/components/views/GoalDetailView.tsx
+++ b/src/components/views/GoalDetailView.tsx
@@ -8,9 +8,10 @@ import DocumentTab from '../tabs/goal/DocumentTab';
 
 interface GoalDetailViewProps {
   goal: any;
+  onBack: () => void;
 }
 
-const GoalDetailView: React.FC<GoalDetailViewProps> = ({ goal }) => {
+const GoalDetailView: React.FC<GoalDetailViewProps> = ({ goal, onBack }) => {
   const [activeTab, setActiveTab] = useState('overview');
   const [editedGoal, setEditedGoal] = useState<any>(goal);
   const [isEditing, setIsEditing] = useState(false);
@@ -78,6 +79,14 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({ goal }) => {
 
   return (
     <div className="bg-white p-4 sm:p-6 rounded-lg shadow border border-gray-200">
+      <div className="mb-4">
+        <button
+          onClick={onBack}
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Back to Goals
+        </button>
+      </div>
       <div className="flex flex-col sm:flex-row justify-between items-start mb-4 gap-4">
         <div className="flex-grow min-w-0">
           <h2 className="text-2xl font-bold text-gray-800 truncate" title={goal.name}>


### PR DESCRIPTION
## Summary
- add `onBack` prop to `GoalDetailView`
- show a **Back to Goals** button at the top of `GoalDetailView`
- wire `GoalPage` to clear the selected goal when back is pressed

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68459f64e210832ba0380e55f7536be5