### PR TITLE
Add basic home page and navigation

### DIFF
--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function HomePage() {
+  return (
+    <section className="bg-white p-4 sm:p-6 rounded-lg shadow space-y-2">
+      <h1 className="text-2xl font-bold">Welcome to LifeManager</h1>
+      <p className="text-gray-700">
+        Manage your habits, projects and goals from a single dashboard.
+      </p>
+    </section>
+  );
+}

--- a/src/components/ui/app-shell-context.tsx
+++ b/src/components/ui/app-shell-context.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { createContext, useContext, useState } from 'react';
 
-type TabName = 'Habits' | 'Projects' | 'Goals' | 'Settings';
+type TabName = 'Home' | 'Habits' | 'Projects' | 'Goals' | 'Settings';
 
 interface ShellCtx {
   activeTab: TabName;
@@ -13,7 +13,7 @@ interface ShellCtx {
 const Ctx = createContext<ShellCtx | null>(null);
 
 export function AppShellProvider({ children }: { children: React.ReactNode }) {
-  const [activeTab, setActiveTab] = useState<TabName>('Projects');
+  const [activeTab, setActiveTab] = useState<TabName>('Home');
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   return (

--- a/src/components/ui/app-shell.tsx
+++ b/src/components/ui/app-shell.tsx
@@ -1,12 +1,13 @@
 'use client';
 import { Button } from '@/components/ui/button';
-import { Menu, X, LogOut, ListTodo, Settings, Target, Repeat } from 'lucide-react';
+import { Menu, X, LogOut, ListTodo, Settings, Target, Repeat, Home } from 'lucide-react';
 import { AppShellProvider, useAppShell } from './app-shell-context';
 
 /* ----- icons mapping for sidebar items ----- */
 const nav = [
+  { name: 'Home', icon: Home },
   { name: 'Habits', icon: Repeat },
-  { name: 'Projects', icon: ListTodo }, 
+  { name: 'Projects', icon: ListTodo },
   { name: 'Goals', icon: Target },
 ] as const;
 

--- a/src/components/ui/dashboard-content.tsx
+++ b/src/components/ui/dashboard-content.tsx
@@ -3,10 +3,13 @@ import { useAppShell } from './app-shell-context';
 import ProjectPage from '../pages/ProjectPage';
 import CommunicationPage from '../pages/CommunicationPage';
 import SettingPage from '../pages/SettingPage';
+import HomePage from '../pages/HomePage';
 
 export default function DashboardContent() {  
   const { activeTab } = useAppShell();
   switch (activeTab) {
+    case 'Home':
+      return <HomePage />;
     case 'Habits':
       return <CommunicationPage />;
     case 'Projects':
@@ -16,6 +19,6 @@ export default function DashboardContent() {
     case 'Settings':
       return <SettingPage />;
     default:
-      return <GoalPage />;
+      return <HomePage />;
   }
 }


### PR DESCRIPTION
## Summary
- add `HomePage` introductory component
- set default `TabName` to Home
- add Home tab and show first in sidebar
- show HomePage when Home tab is active

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68459f6fcc44832bb47d90296fb49a9c