### PR TITLE
Implement Document model and handler

### DIFF
--- a/src/components/tabs/goal/DocumentTab.tsx
+++ b/src/components/tabs/goal/DocumentTab.tsx
@@ -34,11 +34,27 @@ const DocumentTab: React.FC<DocumentTabProps> = ({ goal, isEditing }) => {
     e.preventDefault()
     if (!file) return
     const doc = new Document(0, goal.id, name, type, new Date())
-    await handler.createDocument(doc)
-    setName('')
-    setType('')
-    setFile(null)
-    loadDocuments()
+    try {
+      const created = await handler.createDocument(doc)
+      await handler.uploadDocument(created.id, file)
+      setName('')
+      setType('')
+      setFile(null)
+      loadDocuments()
+    } catch (err) {
+      /* eslint-disable no-console */
+      console.error(err)
+    }
+  }
+
+  const handleDelete = async (id: number) => {
+    try {
+      await handler.deleteDocument(id)
+      loadDocuments()
+    } catch (err) {
+      /* eslint-disable no-console */
+      console.error(err)
+    }
   }
 
   return (
@@ -92,8 +108,9 @@ const DocumentTab: React.FC<DocumentTabProps> = ({ goal, isEditing }) => {
               {isEditing && (
                 <button
                   type="button"
+                  onClick={() => handleDelete(doc.id)}
                   className="text-red-600 hover:text-red-800 p-1 self-end sm:self-center"
-                  title="Löschen (nicht implementiert)"
+                  title="Löschen"
                 >
                   <Trash2 size={16} />
                 </button>

--- a/src/components/tabs/goal/DocumentTab.tsx
+++ b/src/components/tabs/goal/DocumentTab.tsx
@@ -1,61 +1,111 @@
-import React from 'react';
-import { FileText, Trash2 } from 'lucide-react';
-import { formatDate } from '../../helpers';
+import React, { useEffect, useState } from 'react'
+import { FileText, Trash2 } from 'lucide-react'
+import { Goal } from '@/models/Goal'
+import { Document } from '@/models/Document'
+import { DocumentHandler } from '@/models/DocumentHandler'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { formatDate } from '../../helpers'
 
 interface DocumentTabProps {
-  client: any;
-  isEditing: boolean;
+  goal: Goal
+  isEditing: boolean
 }
 
-const DocumentTab: React.FC<DocumentTabProps> = ({ client, isEditing }) => (
-  <div className="space-y-4">
-    <h4 className="text-lg font-semibold mb-2 text-gray-700">Dokumente</h4>
-    <p className="text-sm text-blue-700 bg-blue-100 p-3 rounded-md border border-blue-300">
-      <strong>Hinweis:</strong> Dokumenten-Upload und -Verwaltung erfordern eine Backend-Integration für die Dateispeicherung.
-    </p>
-    {isEditing && (
-      <div className="mb-4 p-4 border border-dashed border-gray-300 rounded-md text-center">
-        <p className="text-gray-500 mb-2 text-sm">Dokument hochladen (Funktion nicht implementiert)</p>
-        <button className="bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-semibold py-1 px-3 rounded">
-          Datei auswählen...
-        </button>
-      </div>
-    )}
-    {client.documents?.length > 0 ? (
-      <ul className="space-y-2">
-        {client.documents.map((doc: any) => (
-          <li
-            key={doc.id}
-            className="p-3 border border-gray-200 rounded-md flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2 bg-gray-50"
+const DocumentTab: React.FC<DocumentTabProps> = ({ goal, isEditing }) => {
+  const [documents, setDocuments] = useState<Document[]>([])
+  const [name, setName] = useState('')
+  const [type, setType] = useState('')
+  const [file, setFile] = useState<File | null>(null)
+  const handler = React.useMemo(() => DocumentHandler.getInstance(), [])
+
+  const loadDocuments = React.useCallback(() => {
+    handler
+      .getDocumentsForGoal(goal.id)
+      .then(setDocuments)
+      .catch(console.error)
+  }, [goal.id, handler])
+
+  useEffect(() => {
+    loadDocuments()
+  }, [loadDocuments])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!file) return
+    const doc = new Document(0, goal.id, name, type, new Date())
+    await handler.createDocument(doc)
+    setName('')
+    setType('')
+    setFile(null)
+    loadDocuments()
+  }
+
+  return (
+    <div className="space-y-4">
+      <h4 className="text-lg font-semibold mb-2 text-gray-700">Dokumente</h4>
+      {isEditing && (
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white shadow rounded p-4 text-gray-800 space-y-2"
+        >
+          <Input
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Name"
+            className="text-sm"
+          />
+          <Input
+            value={type}
+            onChange={e => setType(e.target.value)}
+            placeholder="Typ"
+            className="text-sm"
+          />
+          <Input type="file" onChange={e => setFile(e.target.files?.[0] || null)} />
+          <Button
+            type="submit"
+            className="bg-blue-600 text-white hover:bg-blue-700 px-4 py-2 rounded"
           >
-            <div className="flex items-center space-x-2 flex-grow min-w-0">
-              <FileText size={18} className="text-gray-500 flex-shrink-0" />
-              <div className="min-w-0">
-                <p className="font-medium text-gray-800 text-sm truncate" title={doc.name}>{doc.name}</p>
-                <p className="text-xs text-gray-600">Typ: {doc.type} | Hochgeladen: {formatDate(doc.uploadDate)}</p>
+            Hochladen
+          </Button>
+        </form>
+      )}
+      {documents.length > 0 ? (
+        <ul className="space-y-2">
+          {documents.map(doc => (
+            <li
+              key={doc.id}
+              className="bg-white shadow rounded p-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2 text-gray-800"
+            >
+              <div className="flex items-center space-x-2 flex-grow min-w-0">
+                <FileText size={18} className="text-gray-500 flex-shrink-0" />
+                <div className="min-w-0">
+                  <p className="font-medium text-sm truncate" title={doc.name}>
+                    {doc.name}
+                  </p>
+                  <p className="text-xs text-gray-600">
+                    Typ: {doc.type} | Hochgeladen:{' '}
+                    {formatDate(doc.uploadDate.toISOString())}
+                  </p>
+                </div>
               </div>
-            </div>
-            <div className="flex space-x-2 flex-shrink-0 self-end sm:self-center">
-              <button className="text-blue-600 hover:text-blue-800 p-1" title="Herunterladen (nicht implementiert)">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                  <polyline points="7 10 12 15 17 10" />
-                  <line x1="12" x2="12" y1="15" y2="3" />
-                </svg>
-              </button>
               {isEditing && (
-                <button className="text-red-600 hover:text-red-800 p-1" title="Löschen (nicht implementiert)">
+                <button
+                  type="button"
+                  className="text-red-600 hover:text-red-800 p-1 self-end sm:self-center"
+                  title="Löschen (nicht implementiert)"
+                >
                   <Trash2 size={16} />
                 </button>
               )}
-            </div>
-          </li>
-        ))}
-      </ul>
-    ) : (
-      <p className="text-gray-500 italic text-sm">Keine Dokumente erfasst.</p>
-    )}
-  </div>
-);
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-gray-500 italic text-sm">Keine Dokumente erfasst.</p>
+      )}
+    </div>
+  )
+}
 
-export default DocumentTab;
+export default DocumentTab

--- a/src/components/views/GoalDetailView.tsx
+++ b/src/components/views/GoalDetailView.tsx
@@ -44,6 +44,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({ goal }) => {
 
   const renderTabContent = () => {
     const commonProps = { client: editedGoal, isEditing, onChange: handleInputChange };
+    const documentProps = { goal: editedGoal, isEditing };
     switch (activeTab) {
       case 'overview':
         return <GoalOverviewTab goal={editedGoal} />;
@@ -52,7 +53,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({ goal }) => {
       case 'tasks':
         return <TaskTab {...commonProps} />;
       case 'documents':
-        return <DocumentTab {...commonProps} />;
+        return <DocumentTab {...documentProps} />;
       default:
         return null;
     }

--- a/src/models/Document.ts
+++ b/src/models/Document.ts
@@ -1,0 +1,15 @@
+export class Document {
+  id: number;
+  goalId: number;
+  name: string;
+  type: string;
+  uploadDate: Date;
+
+  constructor(id: number, goalId: number, name: string, type: string, uploadDate: Date) {
+    this.id = id;
+    this.goalId = goalId;
+    this.name = name;
+    this.type = type;
+    this.uploadDate = uploadDate;
+  }
+}

--- a/src/models/DocumentHandler.ts
+++ b/src/models/DocumentHandler.ts
@@ -27,18 +27,26 @@ export class DocumentHandler {
   /** Fetch all documents belonging to a specific goal. */
   async getDocumentsForGoal(goalId: number): Promise<Document[]> {
     const res = await fetch(`${this.baseUrl}/documents?goalId=${goalId}`)
-    const data = await res.json()
-    return data.map(
-      (d: any) => new Document(d.id, d.goalId, d.name, d.type, new Date(d.uploadDate))
-    )
+    if (!res.ok) return []
+    try {
+      const data = await res.json()
+      return data.map(
+        (d: any) => new Document(d.id, d.goalId, d.name, d.type, new Date(d.uploadDate))
+      )
+    } catch {
+      return []
+    }
   }
 
   /** Create a new document entry. */
   async createDocument(document: Document): Promise<void> {
-    await fetch(`${this.baseUrl}/documents`, {
+    const res = await fetch(`${this.baseUrl}/documents`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(document),
     })
+    if (!res.ok) {
+      throw new Error('Failed to create document')
+    }
   }
 }

--- a/src/models/DocumentHandler.ts
+++ b/src/models/DocumentHandler.ts
@@ -1,0 +1,44 @@
+import { Document } from './Document'
+
+/**
+ * DocumentHandler manages document persistence on the backend server.
+ */
+export class DocumentHandler {
+  private static instance: DocumentHandler | null = null
+
+  private baseUrl: string
+
+  private constructor(baseUrl: string) {
+    this.baseUrl = baseUrl
+  }
+
+  static getInstance(baseUrl = 'http://localhost:3001'): DocumentHandler {
+    if (!DocumentHandler.instance) {
+      DocumentHandler.instance = new DocumentHandler(baseUrl)
+    }
+    return DocumentHandler.instance
+  }
+
+  /** Reset the singleton instance (primarily for tests). */
+  static reset(): void {
+    DocumentHandler.instance = null
+  }
+
+  /** Fetch all documents belonging to a specific goal. */
+  async getDocumentsForGoal(goalId: number): Promise<Document[]> {
+    const res = await fetch(`${this.baseUrl}/documents?goalId=${goalId}`)
+    const data = await res.json()
+    return data.map(
+      (d: any) => new Document(d.id, d.goalId, d.name, d.type, new Date(d.uploadDate))
+    )
+  }
+
+  /** Create a new document entry. */
+  async createDocument(document: Document): Promise<void> {
+    await fetch(`${this.baseUrl}/documents`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(document),
+    })
+  }
+}

--- a/src/models/DocumentHandler.ts
+++ b/src/models/DocumentHandler.ts
@@ -38,8 +38,8 @@ export class DocumentHandler {
     }
   }
 
-  /** Create a new document entry. */
-  async createDocument(document: Document): Promise<void> {
+  /** Create a new document entry and return the created item. */
+  async createDocument(document: Document): Promise<Document> {
     const res = await fetch(`${this.baseUrl}/documents`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -47,6 +47,31 @@ export class DocumentHandler {
     })
     if (!res.ok) {
       throw new Error('Failed to create document')
+    }
+    const data = await res.json()
+    return new Document(data.id, data.goalId, data.name, data.type, new Date(data.uploadDate))
+  }
+
+  /** Upload file contents for an existing document. */
+  async uploadDocument(documentId: number, file: File): Promise<void> {
+    const content = await file.text()
+    const res = await fetch(`${this.baseUrl}/documents/${documentId}/upload`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: file.name, content }),
+    })
+    if (!res.ok) {
+      throw new Error('Failed to upload document')
+    }
+  }
+
+  /** Delete a document by id. */
+  async deleteDocument(id: number): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/documents/${id}`, {
+      method: 'DELETE',
+    })
+    if (!res.ok) {
+      throw new Error('Failed to delete document')
     }
   }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,11 +1,13 @@
 import http from 'node:http'
 import { Goal } from '../models/Goal'
 import { Project } from '../models/Project'
+import { Document } from '../models/Document'
 import { Status } from '../types/Status'
 import { AOL } from '../types/AOL'
 
 let goals: Goal[] = []
 let projects: Project[] = []
+let documents: Document[] = []
 
 function initData() {
   goals = [
@@ -67,6 +69,11 @@ function initData() {
       Status.AT_RISK,
       goals[0] || goals[1]
     ),
+  ]
+
+  documents = [
+    new Document(1, goals[0].id, 'Projektplan.pdf', 'pdf', new Date('2025-06-05')),
+    new Document(2, goals[1].id, 'Spezifikation.docx', 'docx', new Date('2025-06-10')),
   ]
 }
 
@@ -170,6 +177,48 @@ export function createServer() {
     if (method === 'POST' && parsed.pathname === '/admin/setProjects') {
       const body = await parseBody(req)
       projects = JSON.parse(body)
+      res.statusCode = 204
+      res.end()
+      return
+    }
+
+    if (method === 'GET' && parsed.pathname === '/documents') {
+      const goalId = parsed.searchParams.get('goalId')
+      const result = goalId
+        ? documents.filter(d => d.goalId === Number(goalId))
+        : documents
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify(result))
+      return
+    }
+
+    if (method === 'POST' && parsed.pathname === '/documents') {
+      const body = await parseBody(req)
+      const doc = JSON.parse(body)
+      documents.push(doc)
+      res.statusCode = 201
+      res.end(JSON.stringify(doc))
+      return
+    }
+
+    if (method === 'DELETE' && parsed.pathname.startsWith('/documents/')) {
+      const id = Number(parsed.pathname.split('/')[2])
+      documents = documents.filter(d => d.id !== id)
+      res.statusCode = 204
+      res.end()
+      return
+    }
+
+    if (method === 'POST' && parsed.pathname === '/admin/clearDocuments') {
+      documents = []
+      res.statusCode = 204
+      res.end()
+      return
+    }
+
+    if (method === 'POST' && parsed.pathname === '/admin/setDocuments') {
+      const body = await parseBody(req)
+      documents = JSON.parse(body)
       res.statusCode = 204
       res.end()
       return


### PR DESCRIPTION
## Summary
- create `Document` domain model
- add `DocumentHandler` with basic CRUD helpers
- fetch and upload documents in `DocumentTab`
- pass goal information down to `DocumentTab`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68459f5fdef4832ba890f0c706f7e3eb