### PR TITLE
Add PDF viewer modal and update mock data

### DIFF
--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { X } from 'lucide-react';
 
 interface ModalProps {
@@ -9,6 +9,14 @@ interface ModalProps {
 }
 
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
   if (!isOpen) return null;
 
   return (

--- a/src/models/DocumentHandler.ts
+++ b/src/models/DocumentHandler.ts
@@ -65,6 +65,16 @@ export class DocumentHandler {
     }
   }
 
+  /** Retrieve a single document including its file content. */
+  async getDocument(id: number): Promise<{ name: string; type: string; content: string | null }> {
+    const res = await fetch(`${this.baseUrl}/documents/${id}`)
+    if (!res.ok) {
+      throw new Error('Failed to fetch document')
+    }
+    const data = await res.json()
+    return { name: data.name, type: data.type, content: data.content }
+  }
+
   /** Delete a document by id. */
   async deleteDocument(id: number): Promise<void> {
     const res = await fetch(`${this.baseUrl}/documents/${id}`, {


### PR DESCRIPTION
## Summary
- serve `Course-Info.pdf` instead of placeholder document
- expose new endpoint to fetch a document with file contents
- add `getDocument` helper to `DocumentHandler`
- show file contents in a modal when clicking a document
- allow modals to close with the Escape key

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684733a162a8832bb4e2045197498203