### PR TITLE
Add project contribution percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ LifeManager accelerates personal goal attainment by turning a high-level aspirat
 ### Project
 - Always linked to one goal
 - Period lies inside the parent goal period
-- Fields: `id`, `name`, progress metrics, `status`, `tasks[]`, `documents[]`
+- Fields: `id`, `name`, progress metrics, `contributionPct`, `status`, `tasks[]`, `documents[]`
 ### Task
 - Atomic action ≤ 1 440 min
 - Fields: `id`, `name`, `description`, `duration`, `priority`, `dependencyIds[]`, `completed`, optional `projectId`

--- a/src/components/tabs/goal/ProjectTab.tsx
+++ b/src/components/tabs/goal/ProjectTab.tsx
@@ -50,7 +50,9 @@ const ProjectTab: React.FC<ProjectTabProps> = ({ goal }) => {
             >
               <div>
                 <p className="font-medium text-sm text-gray-800">{project.name}</p>
-                <p className="text-xs text-gray-500">{project.description}</p>
+                <p className="text-xs text-gray-500">
+                  Contributes {project.contributionPct}% to this goal.
+                </p>
                 <p className="text-xs text-gray-600">
                   {project.period[0].toLocaleDateString()} - {project.period[1].toLocaleDateString()}
                 </p>

--- a/src/components/tabs/goal/ProjectTab.tsx
+++ b/src/components/tabs/goal/ProjectTab.tsx
@@ -50,11 +50,11 @@ const ProjectTab: React.FC<ProjectTabProps> = ({ goal }) => {
             >
               <div>
                 <p className="font-medium text-sm text-gray-800">{project.name}</p>
-                <p className="text-xs text-gray-500">
-                  Contributes {project.contributionPct}% to this goal.
-                </p>
                 <p className="text-xs text-gray-600">
                   {project.period[0].toLocaleDateString()} - {project.period[1].toLocaleDateString()}
+                </p>
+                <p className="text-xs text-gray-500">
+                  Contributes {project.contributionPct}% to this goal.
                 </p>
               </div>
               <span

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -55,7 +55,8 @@ export function initData(): void {
       30,
       100,
       [new Date('2025-01-01'), new Date('2025-12-31')],
-      data.goals[1] || data.goals[0]
+      data.goals[1] || data.goals[0],
+      50
     ),
     new Project(
       2,
@@ -65,7 +66,8 @@ export function initData(): void {
       70,
       100,
       [new Date('2024-06-01'), new Date('2025-06-30')],
-      data.goals[0] || data.goals[1]
+      data.goals[0] || data.goals[1],
+      50
     ),
   ]
 

--- a/src/modal/AddProjectModal.tsx
+++ b/src/modal/AddProjectModal.tsx
@@ -34,6 +34,7 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
     return nextYear.toISOString().slice(0, 10);
   });
   const [goalId, setGoalId] = useState(0);
+  const [contributionPct, setContributionPct] = useState(0);
   useEffect(() => {
     if (goals.length > 0 && goalId === 0) {
       setGoalId(goals[0].id);
@@ -51,7 +52,8 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
       current,
       objective,
       [new Date(startDate), new Date(endDate)],
-      goal
+      goal,
+      contributionPct
     );
     await ProjectHandler.getInstance(GoalHandler.getInstance()).createProject(project);
     if (onCreated) await onCreated();
@@ -69,6 +71,7 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
     setStartDate(today);
     setEndDate(yearLater);
     setGoalId(goals[0]?.id ?? 0);
+    setContributionPct(0);
   };
 
   return (
@@ -119,6 +122,15 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
               className="w-full p-2 border border-gray-300 rounded"
             />
           </div>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Goal Contribution %</label>
+          <input
+            type="number"
+            value={contributionPct}
+            onChange={(e) => setContributionPct(Number(e.target.value))}
+            className="w-full p-2 border border-gray-300 rounded"
+          />
         </div>
         <div className="grid grid-cols-2 gap-2">
           <div>

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -10,6 +10,8 @@ export class Project {
   current: number;
   objective: number;
   period: [Date, Date];
+  /** percentage of this project's contribution to the parent goal */
+  contributionPct: number;
   status: Status;
   goal: Goal;
     
@@ -26,7 +28,7 @@ export class Project {
      * @param goal - Associated goal for the project.
      */
     constructor(id: number, name: string, description: string, start: number, current: number,
-                objective: number, period: [Date, Date], goal: Goal) {
+                objective: number, period: [Date, Date], goal: Goal, contributionPct: number) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -34,6 +36,7 @@ export class Project {
         this.current = current;
         this.objective = objective;
         this.period = period;
+        this.contributionPct = contributionPct;
         this.status = Status.NOT_STARTED;
         this.goal = goal;
         this.updateStatus();

--- a/src/models/ProjectHandler.test.ts
+++ b/src/models/ProjectHandler.test.ts
@@ -12,7 +12,7 @@ function createGoal(id: number): Goal {
 }
 
 function createProject(id: number, goal: Goal): Project {
-  return new Project(id, `p${id}`, '', 0, 0, 1, [new Date(), new Date()], goal)
+  return new Project(id, `p${id}`, '', 0, 0, 1, [new Date(), new Date()], goal, 10)
 }
 
 test('createProject adds a project', async () => {

--- a/src/models/ProjectHandler.ts
+++ b/src/models/ProjectHandler.ts
@@ -86,7 +86,8 @@ export class ProjectHandler {
             p.goal.objective,
             [new Date(p.goal.period[0]), new Date(p.goal.period[1])],
             p.goal.aol
-          )
+          ),
+          p.contributionPct
         )
     )
   }
@@ -114,7 +115,8 @@ export class ProjectHandler {
             p.goal.objective,
             [new Date(p.goal.period[0]), new Date(p.goal.period[1])],
             p.goal.aol
-          )
+          ),
+          p.contributionPct
         )
     )
   }
@@ -148,7 +150,8 @@ export class ProjectHandler {
           p.goal.objective,
           [new Date(p.goal.period[0]), new Date(p.goal.period[1])],
           p.goal.aol
-        )
+        ),
+        p.contributionPct
       )
     return Array.isArray(data) ? data.map(map) : [map(data)]
   }

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -64,7 +64,8 @@ export async function handleProjectRequests(
       0,
       100,
       goal.period,
-      goal
+      goal,
+      100
     )
 
     data.projects.push(project)

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -71,6 +71,7 @@ test('POST /projects creates a project', async () => {
     objective: 1,
     period: [new Date(), new Date()],
     status: 'Not Started',
+    contributionPct: 10,
     goal: {
       id: 1,
       name: 'g',
@@ -98,6 +99,7 @@ test('DELETE /projects removes a project', async () => {
     objective: 1,
     period: [new Date(), new Date()],
     status: 'Not Started',
+    contributionPct: 10,
     goal: {
       id: 1,
       name: 'g',


### PR DESCRIPTION
## Summary
- extend `Project` model with `contributionPct`
- allow entering contribution when adding projects
- propagate new field through handlers, routes and tests
- seed sample data with contribution values
- document new property

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485756c0e8832b898ccf085222acdd