### PR TITLE
Fix Tailwind after upgrade

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    '@tailwindcss/postcss': { config: './tailwind.config.js' },
   },
 };
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,9 +78,10 @@ body {
 
 @layer base {
   * {
-    @apply border-border;
+    border-color: hsl(var(--border));
   }
   body {
-    @apply bg-background text-foreground;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,11 @@
-import type { Config } from "tailwindcss";
-
-export default {
-	darkMode: "class",
-    content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/styles/**/*.{js,ts,jsx,tsx,mdx}",
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/styles/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
   	extend: {
@@ -91,5 +90,5 @@ export default {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate"), require("flowbite/plugin")],
-} satisfies Config;
+  plugins: [require('tailwindcss-animate'), require('flowbite/plugin')],
+};


### PR DESCRIPTION
## Summary
- convert Tailwind config to JS and reference it from PostCSS
- replace unsupported `@apply` usages with CSS variables

## Testing
- `npm run build`
- `npm run lint` *(fails: Cannot find module 'next/dist/compiled/babel/eslint-parser')*

------
https://chatgpt.com/codex/tasks/task_e_684967130948832b8fd8ca3cf3f0cb7e