### PR TITLE
Fix project topic markdown rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-chartjs-2": "^5.3.0",
     "react-hook-form": "^7.54.2",
     "react-markdown": "^9.1.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "remark-gfm": "^3.0.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.9",
@@ -62,6 +63,7 @@
     "react-dom": "^19.1.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.9",
+    "@tailwindcss/typography": "^0.5.10",
     "typescript": "^5",
     "vite": "^6.3.5"
   }

--- a/src/components/tabs/project/OverviewTab.tsx
+++ b/src/components/tabs/project/OverviewTab.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { Project } from '@/models/Project'
 import { Topic } from '@/models/Topic'
 import { Chat } from '@/models/Chat'
@@ -80,7 +81,38 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ project }) => {
           title={activeTopic.name}
         >
           <div className="space-y-4">
-            <ReactMarkdown className="text-sm text-gray-800">{markdown}</ReactMarkdown>
+            <ReactMarkdown
+              className="prose max-w-none text-gray-800"
+              remarkPlugins={[remarkGfm]}
+              components={{
+                h1: ({ node, ...props }) => (
+                  <h1
+                    className="text-xl font-bold border-b border-gray-200 pb-1 mt-4 first:mt-0"
+                    {...props}
+                  />
+                ),
+                h2: ({ node, ...props }) => (
+                  <h2
+                    className="text-lg font-semibold border-b border-gray-200 pb-1 mt-3 first:mt-0"
+                    {...props}
+                  />
+                ),
+                table: ({ node, ...props }) => (
+                  <table
+                    className="min-w-full border border-gray-300 text-sm"
+                    {...props}
+                  />
+                ),
+                th: ({ node, ...props }) => (
+                  <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
+                ),
+                td: ({ node, ...props }) => (
+                  <td className="border px-2 py-1" {...props} />
+                ),
+              }}
+            >
+              {markdown}
+            </ReactMarkdown>
             {chats.map(chat => (
               <div
                 key={chat.id}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -91,5 +91,9 @@ export default {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate"), require("flowbite/plugin")],
+  plugins: [
+    require("tailwindcss-animate"),
+    require("@tailwindcss/typography"),
+    require("flowbite/plugin"),
+  ],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- render project topic markdown with GitHub Flavored Markdown
- style heading and table markdown elements
- enable typography plugin for Tailwind
- add remark-gfm and tailwind typography dependencies

## Testing
- `npm run lint` *(fails: Mixed spaces and tabs)*

------
https://chatgpt.com/codex/tasks/task_e_6849f14856c8832b826877791ce731b6