### PR TITLE
Fix inline equations with MathJax config

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -10,6 +10,14 @@
     <script type="module" src="/src/main.tsx"></script>
     <script src="./node_modules/flowbite/dist/flowbite.min.js"></script>
     <!-- MathJax for rendering LaTeX in markdown -->
+    <script>
+      window.MathJax = {
+        tex: {
+          inlineMath: [['$', '$'], ['\\(', '\\)']],
+          displayMath: [['$$', '$$'], ['\\[', '\\]']],
+        },
+      }
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- configure MathJax to support `$...$` inline equations and `$$...$$` display blocks

## Testing
- `npm run lint` *(fails: 277 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b0328a3e4832bbdf3882a7632bac6