### PR TITLE
Add Topic tab and redesign Project detail overview

### DIFF
--- a/app/src/components/tabs/project/OverviewTab.tsx
+++ b/app/src/components/tabs/project/OverviewTab.tsx
@@ -2,143 +2,81 @@ import React, { useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Project } from '@shared/models/Project'
-import { Topic } from '@shared/models/Topic'
-import { Chat } from '@shared/models/Chat'
+import { TaskHandler } from '@shared/models/TaskHandler'
 import { TopicHandler } from '@shared/models/TopicHandler'
-import { ChatHandler } from '@shared/models/ChatHandler'
-import Modal from '@/components/ui/modal'
-import ChatView from '@/components/views/ChatView'
+import { DocumentHandler } from '@shared/models/DocumentHandler'
+import { Progbar } from '@/components/ui/progress-bar'
+import { Separator } from '@/components/ui/separator'
 
 interface OverviewTabProps {
   project: Project
 }
 
 const OverviewTab: React.FC<OverviewTabProps> = ({ project }) => {
-  const [topics, setTopics] = useState<Topic[]>([])
-  const [activeTopic, setActiveTopic] = useState<Topic | null>(null)
-  const [chats, setChats] = useState<Chat[]>([])
-  const [activeChat, setActiveChat] = useState<Chat | null>(null)
-  const [chatCounts, setChatCounts] = useState<Record<number, number>>({})
-  const [markdown, setMarkdown] = useState('')
+  const [counts, setCounts] = useState({ tasks: 0, topics: 0, documents: 0 })
+  const taskHandler = React.useMemo(() => TaskHandler.getInstance(), [])
   const topicHandler = React.useMemo(() => TopicHandler.getInstance(), [])
-  const chatHandler = React.useMemo(() => ChatHandler.getInstance(), [])
+  const documentHandler = React.useMemo(() => DocumentHandler.getInstance(), [])
 
   useEffect(() => {
-    topicHandler
-      .getTopicsForProject(project.id)
-      .then(setTopics)
-      .catch(() => setTopics([]))
-  }, [project.id, topicHandler])
-
-  useEffect(() => {
-    if (topics.length === 0) return
-    Promise.all(
-      topics.map(async t => {
-        const list = await chatHandler.getChatsForTopic(t.id)
-        return [t.id, list.length] as const
-      })
-    ).then(entries => {
-      setChatCounts(Object.fromEntries(entries))
-    })
-  }, [topics, chatHandler])
-
-  const openTopic = async (topic: Topic) => {
-    setActiveTopic(topic)
-    const [list, md] = await Promise.all([
-      chatHandler.getChatsForTopic(topic.id),
-      topicHandler.getMarkdownForTopic(topic.id),
+    Promise.all([
+      taskHandler.getTasksForProject(project.id),
+      topicHandler.getTopicsForProject(project.id),
+      documentHandler.getDocumentsForProject(project.id),
     ])
-    setChats(list)
-    setMarkdown(md)
-  }
+      .then(([t, tp, d]) =>
+        setCounts({ tasks: t.length, topics: tp.length, documents: d.length })
+      )
+      .catch(() => setCounts({ tasks: 0, topics: 0, documents: 0 }))
+  }, [project.id, taskHandler, topicHandler, documentHandler])
+
+  const progress = Math.round(project.progressPercentage)
+  const time = Math.round(project.timePercentage)
 
   useEffect(() => {
-    if (markdown && (window as any).MathJax?.typeset) {
-      (window as any).MathJax.typeset()
+    if ((window as any).MathJax?.typeset) {
+      ;(window as any).MathJax.typeset()
     }
-  }, [markdown])
+  }, [project.description])
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {topics.map(t => (
-          <div
-            key={t.id}
-            onClick={() => openTopic(t)}
-            className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow flex flex-col gap-2"
-          >
-            <h3 className="font-medium text-gray-800">{t.name}</h3>
-            <div className="flex space-x-1">
-              {Array.from({ length: chatCounts[t.id] || 0 }).map((_, i) => (
-                <span key={i} className="w-2 h-2 bg-blue-600 rounded-full" />
-              ))}
-            </div>
-          </div>
-        ))}
+      <div className="flex justify-around border-b border-gray-200 pb-4">
+        <div className="flex flex-col items-center flex-1">
+          <span className="text-2xl font-bold text-gray-800">{counts.tasks}</span>
+          <span className="text-sm text-gray-600">Tasks</span>
+        </div>
+        <Separator orientation="vertical" className="mx-2" />
+        <div className="flex flex-col items-center flex-1">
+          <span className="text-2xl font-bold text-gray-800">{counts.topics}</span>
+          <span className="text-sm text-gray-600">Topics</span>
+        </div>
+        <Separator orientation="vertical" className="mx-2" />
+        <div className="flex flex-col items-center flex-1">
+          <span className="text-2xl font-bold text-gray-800">{counts.documents}</span>
+          <span className="text-sm text-gray-600">Documents</span>
+        </div>
       </div>
-
-      {activeTopic && (
-        <Modal
-          isOpen={!!activeTopic}
-          onClose={() => {
-            setActiveTopic(null)
-            setChats([])
-            setMarkdown('')
-          }}
-          title={activeTopic.name}
-        >
-          <div className="space-y-4">
-            <ReactMarkdown
-              className="prose max-w-none text-gray-800"
-              remarkPlugins={[remarkGfm]}
-              components={{
-                h1: ({ node, ...props }) => (
-                  <h1
-                    className="text-xl font-bold border-b border-gray-200 pb-1 mt-4 first:mt-0"
-                    {...props}
-                  />
-                ),
-                h2: ({ node, ...props }) => (
-                  <h2
-                    className="text-lg font-semibold border-b border-gray-200 pb-1 mt-3 first:mt-0"
-                    {...props}
-                  />
-                ),
-                table: ({ node, ...props }) => (
-                  <table
-                    className="min-w-full border border-gray-300 text-sm"
-                    {...props}
-                  />
-                ),
-                th: ({ node, ...props }) => (
-                  <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
-                ),
-                td: ({ node, ...props }) => (
-                  <td className="border px-2 py-1" {...props} />
-                ),
-              }}
-            >
-              {markdown}
-            </ReactMarkdown>
-            {chats.map(chat => (
-              <div
-                key={chat.id}
-                onClick={() => setActiveChat(chat)}
-                className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow"
-              >
-                <h4 className="font-medium text-sm text-gray-800">{chat.title}</h4>
-                <p className="text-xs text-gray-600">{chat.description}</p>
-              </div>
-            ))}
-          </div>
-        </Modal>
-      )}
-
-      {activeChat && (
-        <Modal isOpen={!!activeChat} onClose={() => setActiveChat(null)} title={activeChat.title}>
-          <ChatView chat={activeChat} />
-        </Modal>
-      )}
+      <div className="space-y-2">
+        <Progbar name="Time" progress={time} />
+        <Progbar name="Progress" progress={progress} />
+      </div>
+      <Separator className="my-2" />
+      <ReactMarkdown
+        className="prose max-w-none text-gray-800"
+        remarkPlugins={[remarkGfm]}
+        components={{
+          table: ({ node, ...props }) => (
+            <table className="min-w-full border border-gray-300 text-sm" {...props} />
+          ),
+          th: ({ node, ...props }) => (
+            <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
+          ),
+          td: ({ node, ...props }) => <td className="border px-2 py-1" {...props} />,
+        }}
+      >
+        {project.description}
+      </ReactMarkdown>
     </div>
   )
 }

--- a/app/src/components/tabs/project/TaskTab.tsx
+++ b/app/src/components/tabs/project/TaskTab.tsx
@@ -52,9 +52,20 @@ const TaskTab: React.FC<TaskTabProps> = ({ project }) => {
                 <p className="text-xs text-gray-600">Due {task.deadline.toLocaleDateString()}</p>
                 <p className="text-xs text-gray-500">Duration {(task.duration / 3600).toFixed(1)}h</p>
               </div>
-              <span className="bg-blue-200 text-blue-800 flex-shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full">
-                {task.project.name}
-              </span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className="p-1 rounded-full bg-blue-600 text-white hover:bg-blue-700"
+                >
+                  <Sparkles size={16} />
+                </button>
+                <button
+                  type="button"
+                  className="p-1 rounded-full bg-blue-600 text-white hover:bg-blue-700"
+                >
+                  <Sparkles size={16} />
+                </button>
+              </div>
             </li>
           ))}
         </ul>

--- a/app/src/components/tabs/project/TopicTab.tsx
+++ b/app/src/components/tabs/project/TopicTab.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Project } from '@shared/models/Project'
+import { Topic } from '@shared/models/Topic'
+import { Chat } from '@shared/models/Chat'
+import { TopicHandler } from '@shared/models/TopicHandler'
+import { ChatHandler } from '@shared/models/ChatHandler'
+import Modal from '@/components/ui/modal'
+import ChatView from '@/components/views/ChatView'
+
+interface TopicTabProps {
+  project: Project
+}
+
+const TopicTab: React.FC<TopicTabProps> = ({ project }) => {
+  const [topics, setTopics] = useState<Topic[]>([])
+  const [activeTopic, setActiveTopic] = useState<Topic | null>(null)
+  const [chats, setChats] = useState<Chat[]>([])
+  const [activeChat, setActiveChat] = useState<Chat | null>(null)
+  const [chatCounts, setChatCounts] = useState<Record<number, number>>({})
+  const [markdown, setMarkdown] = useState('')
+  const topicHandler = React.useMemo(() => TopicHandler.getInstance(), [])
+  const chatHandler = React.useMemo(() => ChatHandler.getInstance(), [])
+
+  useEffect(() => {
+    topicHandler
+      .getTopicsForProject(project.id)
+      .then(setTopics)
+      .catch(() => setTopics([]))
+  }, [project.id, topicHandler])
+
+  useEffect(() => {
+    if (topics.length === 0) return
+    Promise.all(
+      topics.map(async t => {
+        const list = await chatHandler.getChatsForTopic(t.id)
+        return [t.id, list.length] as const
+      })
+    ).then(entries => {
+      setChatCounts(Object.fromEntries(entries))
+    })
+  }, [topics, chatHandler])
+
+  const openTopic = async (topic: Topic) => {
+    setActiveTopic(topic)
+    const [list, md] = await Promise.all([
+      chatHandler.getChatsForTopic(topic.id),
+      topicHandler.getMarkdownForTopic(topic.id),
+    ])
+    setChats(list)
+    setMarkdown(md)
+  }
+
+  useEffect(() => {
+    if (markdown && (window as any).MathJax?.typeset) {
+      (window as any).MathJax.typeset()
+    }
+  }, [markdown])
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {topics.map(t => (
+          <div
+            key={t.id}
+            onClick={() => openTopic(t)}
+            className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow flex flex-col gap-2"
+          >
+            <h3 className="font-medium text-gray-800">{t.name}</h3>
+            <div className="flex space-x-1">
+              {Array.from({ length: chatCounts[t.id] || 0 }).map((_, i) => (
+                <span key={i} className="w-2 h-2 bg-blue-600 rounded-full" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {activeTopic && (
+        <Modal
+          isOpen={!!activeTopic}
+          onClose={() => {
+            setActiveTopic(null)
+            setChats([])
+            setMarkdown('')
+          }}
+          title={activeTopic.name}
+        >
+          <div className="space-y-4">
+            <ReactMarkdown
+              className="prose max-w-none text-gray-800"
+              remarkPlugins={[remarkGfm]}
+              components={{
+                h1: ({ node, ...props }) => (
+                  <h1
+                    className="text-xl font-bold border-b border-gray-200 pb-1 mt-4 first:mt-0"
+                    {...props}
+                  />
+                ),
+                h2: ({ node, ...props }) => (
+                  <h2
+                    className="text-lg font-semibold border-b border-gray-200 pb-1 mt-3 first:mt-0"
+                    {...props}
+                  />
+                ),
+                table: ({ node, ...props }) => (
+                  <table
+                    className="min-w-full border border-gray-300 text-sm"
+                    {...props}
+                  />
+                ),
+                th: ({ node, ...props }) => (
+                  <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
+                ),
+                td: ({ node, ...props }) => (
+                  <td className="border px-2 py-1" {...props} />
+                ),
+              }}
+            >
+              {markdown}
+            </ReactMarkdown>
+            {chats.map(chat => (
+              <div
+                key={chat.id}
+                onClick={() => setActiveChat(chat)}
+                className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow"
+              >
+                <h4 className="font-medium text-sm text-gray-800">{chat.title}</h4>
+                <p className="text-xs text-gray-600">{chat.description}</p>
+              </div>
+            ))}
+          </div>
+        </Modal>
+      )}
+
+      {activeChat && (
+        <Modal isOpen={!!activeChat} onClose={() => setActiveChat(null)} title={activeChat.title}>
+          <ChatView chat={activeChat} />
+        </Modal>
+      )}
+    </div>
+  )
+}
+
+export default TopicTab

--- a/app/src/components/views/ProjectDetailView.tsx
+++ b/app/src/components/views/ProjectDetailView.tsx
@@ -3,12 +3,14 @@ import {
   ArrowLeft,
   FileText,
   Calendar,
+  Sparkles,
   ChartNoAxesCombined,
   LucideProps,
 } from 'lucide-react'
 import { Project } from '@shared/models/Project'
 import OverviewTab from '../tabs/project/OverviewTab'
 import TaskTab from '../tabs/project/TaskTab'
+import TopicTab from '../tabs/project/TopicTab'
 import DocumentTab from '../tabs/project/DocumentTab'
 
 interface ProjectDetailViewProps {
@@ -31,6 +33,8 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({ project, onBack }
         return <OverviewTab project={currentProject} />
       case 'tasks':
         return <TaskTab project={currentProject} />
+      case 'topics':
+        return <TopicTab project={currentProject} />
       case 'documents':
         return <DocumentTab project={currentProject} />
       default:
@@ -68,6 +72,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({ project, onBack }
         <nav className="flex space-x-2 overflow-x-auto whitespace-nowrap pb-2" aria-label="Tabs">
           <TabButton tabId="overview" label="Overview" icon={ChartNoAxesCombined} />
           <TabButton tabId="tasks" label="Tasks" icon={Calendar} />
+          <TabButton tabId="topics" label="Topics" icon={Sparkles} />
           <TabButton tabId="documents" label="Documents" icon={FileText} />
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- add a dedicated TopicTab to show project topics
- update OverviewTab with counts, progress bars and markdown description
- replace project name in TaskTab with two action buttons
- insert Topic tab in ProjectDetailView navigation

## Testing
- `npm run lint` *(fails: 283 errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_684bcb996748832b8d7db5118ff46b24