### PR TITLE
Add project summaries and topic empty state

### DIFF
--- a/app/src/components/tabs/project/TopicTab.tsx
+++ b/app/src/components/tabs/project/TopicTab.tsx
@@ -60,22 +60,26 @@ const TopicTab: React.FC<TopicTabProps> = ({ project }) => {
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {topics.map(t => (
-          <div
-            key={t.id}
-            onClick={() => openTopic(t)}
-            className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow flex flex-col gap-2"
-          >
-            <h3 className="font-medium text-gray-800">{t.name}</h3>
-            <div className="flex space-x-1">
-              {Array.from({ length: chatCounts[t.id] || 0 }).map((_, i) => (
-                <span key={i} className="w-2 h-2 bg-blue-600 rounded-full" />
-              ))}
+      {topics.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {topics.map(t => (
+            <div
+              key={t.id}
+              onClick={() => openTopic(t)}
+              className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow flex flex-col gap-2"
+            >
+              <h3 className="font-medium text-gray-800">{t.name}</h3>
+              <div className="flex space-x-1">
+                {Array.from({ length: chatCounts[t.id] || 0 }).map((_, i) => (
+                  <span key={i} className="w-2 h-2 bg-blue-600 rounded-full" />
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-gray-500 italic text-sm">No topics for this project.</p>
+      )}
 
       {activeTopic && (
         <Modal

--- a/app/src/components/tabs/project/TopicTab.tsx
+++ b/app/src/components/tabs/project/TopicTab.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { Project } from '@shared/models/Project'
 import { Topic } from '@shared/models/Topic'
 import { Chat } from '@shared/models/Chat'
@@ -8,6 +6,7 @@ import { TopicHandler } from '@shared/models/TopicHandler'
 import { ChatHandler } from '@shared/models/ChatHandler'
 import Modal from '@/components/ui/modal'
 import ChatView from '@/components/views/ChatView'
+import TopicDetailView from '@/components/views/TopicDetailView'
 
 interface TopicTabProps {
   project: Project
@@ -48,78 +47,37 @@ const TopicTab: React.FC<TopicTabProps> = ({ project }) => {
 
   return (
     <div className="space-y-4">
-      {topics.length > 0 ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {topics.map(t => (
-            <div
-              key={t.id}
-              onClick={() => openTopic(t)}
-              className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow flex flex-col gap-2"
-            >
-              <h3 className="font-medium text-gray-800">{t.name}</h3>
-              <p className="text-sm text-gray-600 line-clamp-2">{t.shortDescription}</p>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <p className="text-gray-500 italic text-sm">No topics for this project.</p>
-      )}
-
-      {activeTopic && (
-        <Modal
-          isOpen={!!activeTopic}
-          onClose={() => {
+      {activeTopic ? (
+        <TopicDetailView
+          topic={activeTopic}
+          markdown={markdown}
+          chats={chats}
+          onBack={() => {
             setActiveTopic(null)
             setChats([])
             setMarkdown('')
           }}
-          title={activeTopic.name}
-        >
-          <div className="space-y-4">
-            <ReactMarkdown
-              className="prose max-w-none text-gray-800"
-              remarkPlugins={[remarkGfm]}
-              components={{
-                h1: ({ node, ...props }) => (
-                  <h1
-                    className="text-xl font-bold border-b border-gray-200 pb-1 mt-4 first:mt-0"
-                    {...props}
-                  />
-                ),
-                h2: ({ node, ...props }) => (
-                  <h2
-                    className="text-lg font-semibold border-b border-gray-200 pb-1 mt-3 first:mt-0"
-                    {...props}
-                  />
-                ),
-                table: ({ node, ...props }) => (
-                  <table
-                    className="min-w-full border border-gray-300 text-sm"
-                    {...props}
-                  />
-                ),
-                th: ({ node, ...props }) => (
-                  <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
-                ),
-                td: ({ node, ...props }) => (
-                  <td className="border px-2 py-1" {...props} />
-                ),
-              }}
-            >
-              {markdown}
-            </ReactMarkdown>
-            {chats.map(chat => (
-              <div
-                key={chat.id}
-                onClick={() => setActiveChat(chat)}
-                className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow"
-              >
-                <h4 className="font-medium text-sm text-gray-800">{chat.title}</h4>
-                <p className="text-xs text-gray-600">{chat.description}</p>
-              </div>
-            ))}
-          </div>
-        </Modal>
+          onOpenChat={chat => setActiveChat(chat)}
+        />
+      ) : (
+        <>
+          {topics.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {topics.map(t => (
+                <div
+                  key={t.id}
+                  onClick={() => openTopic(t)}
+                  className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow flex flex-col gap-2"
+                >
+                  <h3 className="font-medium text-gray-800">{t.name}</h3>
+                  <p className="text-sm text-gray-600 line-clamp-2">{t.shortDescription}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-gray-500 italic text-sm">No topics for this project.</p>
+          )}
+        </>
       )}
 
       {activeChat && (

--- a/app/src/components/tabs/project/TopicTab.tsx
+++ b/app/src/components/tabs/project/TopicTab.tsx
@@ -18,7 +18,6 @@ const TopicTab: React.FC<TopicTabProps> = ({ project }) => {
   const [activeTopic, setActiveTopic] = useState<Topic | null>(null)
   const [chats, setChats] = useState<Chat[]>([])
   const [activeChat, setActiveChat] = useState<Chat | null>(null)
-  const [chatCounts, setChatCounts] = useState<Record<number, number>>({})
   const [markdown, setMarkdown] = useState('')
   const topicHandler = React.useMemo(() => TopicHandler.getInstance(), [])
   const chatHandler = React.useMemo(() => ChatHandler.getInstance(), [])
@@ -30,17 +29,6 @@ const TopicTab: React.FC<TopicTabProps> = ({ project }) => {
       .catch(() => setTopics([]))
   }, [project.id, topicHandler])
 
-  useEffect(() => {
-    if (topics.length === 0) return
-    Promise.all(
-      topics.map(async t => {
-        const list = await chatHandler.getChatsForTopic(t.id)
-        return [t.id, list.length] as const
-      })
-    ).then(entries => {
-      setChatCounts(Object.fromEntries(entries))
-    })
-  }, [topics, chatHandler])
 
   const openTopic = async (topic: Topic) => {
     setActiveTopic(topic)
@@ -69,11 +57,7 @@ const TopicTab: React.FC<TopicTabProps> = ({ project }) => {
               className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow flex flex-col gap-2"
             >
               <h3 className="font-medium text-gray-800">{t.name}</h3>
-              <div className="flex space-x-1">
-                {Array.from({ length: chatCounts[t.id] || 0 }).map((_, i) => (
-                  <span key={i} className="w-2 h-2 bg-blue-600 rounded-full" />
-                ))}
-              </div>
+              <p className="text-sm text-gray-600 line-clamp-2">{t.shortDescription}</p>
             </div>
           ))}
         </div>

--- a/app/src/components/views/TopicDetailView.tsx
+++ b/app/src/components/views/TopicDetailView.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { ArrowLeft } from 'lucide-react'
+import { Topic } from '@shared/models/Topic'
+import { Chat } from '@shared/models/Chat'
+
+interface TopicDetailViewProps {
+  topic: Topic
+  markdown: string
+  chats: Chat[]
+  onBack: () => void
+  onOpenChat: (chat: Chat) => void
+}
+
+const TopicDetailView: React.FC<TopicDetailViewProps> = ({
+  topic,
+  markdown,
+  chats,
+  onBack,
+  onOpenChat,
+}) => {
+  useEffect(() => {
+    if ((window as any).MathJax?.typeset) {
+      ;(window as any).MathJax.typeset()
+    }
+  }, [markdown])
+
+  return (
+    <div className="bg-white p-4 sm:p-6 rounded-lg shadow border border-gray-200">
+      <div className="flex items-center gap-2 mb-4">
+        <button onClick={onBack} aria-label="Back to Topics">
+          <ArrowLeft size={20} />
+        </button>
+        <h3 className="text-xl font-bold text-gray-800 truncate" title={topic.name}>
+          {topic.name}
+        </h3>
+      </div>
+      <ReactMarkdown
+        className="prose max-w-none text-gray-800 mb-4"
+        remarkPlugins={[remarkGfm]}
+        components={{
+          table: ({ node, ...props }) => (
+            <table className="min-w-full border border-gray-300 text-sm" {...props} />
+          ),
+          th: ({ node, ...props }) => (
+            <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
+          ),
+          td: ({ node, ...props }) => <td className="border px-2 py-1" {...props} />,
+        }}
+      >
+        {markdown}
+      </ReactMarkdown>
+      <div className="space-y-2">
+        {chats.map(chat => (
+          <div
+            key={chat.id}
+            onClick={() => onOpenChat(chat)}
+            className="bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer hover:shadow"
+          >
+            <h4 className="font-medium text-sm text-gray-800">{chat.title}</h4>
+            <p className="text-xs text-gray-600">{chat.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default TopicDetailView

--- a/app/src/modals/AddProjectModal.tsx
+++ b/app/src/modals/AddProjectModal.tsx
@@ -20,6 +20,7 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
       .catch(() => setGoals([]));
   }, []);
   const [name, setName] = useState('');
+  const [shortDescription, setShortDescription] = useState('');
   const [description, setDescription] = useState('');
   const [start, setStart] = useState(0);
   const [current, setCurrent] = useState(0);
@@ -47,6 +48,7 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
     const project = new Project(
       Date.now(),
       name,
+      shortDescription,
       description,
       start,
       current,
@@ -60,6 +62,7 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
     onClose();
     // reset fields
     setName('');
+    setShortDescription('');
     setDescription('');
     setStart(0);
     setCurrent(0);
@@ -77,20 +80,29 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Add Project">
       <div className="space-y-4">
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="w-full p-2 border border-gray-300 rounded"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
-          <textarea
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full p-2 border border-gray-300 rounded"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Short Description</label>
+        <input
+          type="text"
+          value={shortDescription}
+          onChange={(e) => setShortDescription(e.target.value)}
+          className="w-full p-2 border border-gray-300 rounded"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
             className="w-full p-2 border border-gray-300 rounded"
           />
         </div>

--- a/app/src/pages/ProjectPage.tsx
+++ b/app/src/pages/ProjectPage.tsx
@@ -21,7 +21,9 @@ export default function ProjectPage() {
   const [search, setSearch] = useState("");
 
   const filtered = projects.filter((p) =>
-    `${p.name} ${p.description}`.toLowerCase().includes(search.toLowerCase()),
+    `${p.name} ${p.shortDescription} ${p.description}`
+      .toLowerCase()
+      .includes(search.toLowerCase()),
   );
 
   return (
@@ -67,7 +69,7 @@ export default function ProjectPage() {
                   className={`${containerStyle[project.status]} p-4 rounded-lg shadow hover:shadow-md transition-shadow cursor-pointer border border-gray-200`}
                 >
                   <h2 className="text-lg font-semibold">{project.name}</h2>
-                  <p className="text-sm text-gray-600 line-clamp-3">{project.description}</p>
+                  <p className="text-sm text-gray-600 line-clamp-3">{project.shortDescription}</p>
                   <span className={`${statusLabelStyle[project.status]} flex-shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full `}>
                     {project.status}
                   </span>

--- a/app/src/pages/ProjectPage.tsx
+++ b/app/src/pages/ProjectPage.tsx
@@ -70,7 +70,9 @@ export default function ProjectPage() {
                 >
                   <h2 className="text-lg font-semibold">{project.name}</h2>
                   <p className="text-sm text-gray-600 line-clamp-3">{project.shortDescription}</p>
-                  <span className={`${statusLabelStyle[project.status]} flex-shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full mt-auto`}> 
+                  <span
+                    className={`${statusLabelStyle[project.status]} flex-shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full mt-auto self-start`}
+                  >
                     {project.status}
                   </span>
                 </div>

--- a/app/src/pages/ProjectPage.tsx
+++ b/app/src/pages/ProjectPage.tsx
@@ -66,11 +66,11 @@ export default function ProjectPage() {
                 <div
                   key={project.id}
                   onClick={() => setSelectedProject(project)}
-                  className={`${containerStyle[project.status]} p-4 rounded-lg shadow hover:shadow-md transition-shadow cursor-pointer border border-gray-200`}
+                  className={`${containerStyle[project.status]} p-4 rounded-lg shadow hover:shadow-md transition-shadow cursor-pointer border border-gray-200 flex flex-col h-full`}
                 >
                   <h2 className="text-lg font-semibold">{project.name}</h2>
                   <p className="text-sm text-gray-600 line-clamp-3">{project.shortDescription}</p>
-                  <span className={`${statusLabelStyle[project.status]} flex-shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full `}>
+                  <span className={`${statusLabelStyle[project.status]} flex-shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full mt-auto`}> 
                     {project.status}
                   </span>
                 </div>

--- a/server/src/data/data.ts
+++ b/server/src/data/data.ts
@@ -82,6 +82,7 @@ export function initData(): void {
       1,
       'Solar Farm Expansion',
       'Expand the regional solar farm to 150\u202FMW capacity to support grid stability and meet renewable\u2011energy targets.',
+      fs.readFileSync(path.join(__dirname, 'projects', 'solar-farm-expansion.md'), 'utf8'),
       0,
       30,
       100,
@@ -93,6 +94,7 @@ export function initData(): void {
       2,
       'ERP Roll\u2011out',
       'Implement a company\u2011wide ERP solution to unify finance, supply\u2011chain, and HR operations across all business units.',
+      fs.readFileSync(path.join(__dirname, 'projects', 'erp-rollout.md'), 'utf8'),
       0,
       70,
       100,
@@ -103,6 +105,7 @@ export function initData(): void {
     new Project(
       3,
       'Advanced Algorithms',
+      'Study advanced algorithms in depth.',
       fs.readFileSync(
         path.join(__dirname, 'projects', 'advanced-algorithms.md'),
         'utf8'

--- a/server/src/data/data.ts
+++ b/server/src/data/data.ts
@@ -135,9 +135,24 @@ export function initData(): void {
   ]
 
   data.topics = [
-    new Topic(1, 'Graph Algorithms', data.projects[2]),
-    new Topic(2, 'Approximation Algorithms', data.projects[2]),
-    new Topic(3, 'Randomized Algorithms', data.projects[2]),
+    new Topic(
+      1,
+      'Graph Algorithms',
+      'Explores fundamental graph algorithms and their applications.',
+      data.projects[2]
+    ),
+    new Topic(
+      2,
+      'Approximation Algorithms',
+      'Discusses strategies for near-optimal solutions to hard problems.',
+      data.projects[2]
+    ),
+    new Topic(
+      3,
+      'Randomized Algorithms',
+      'Examines algorithms that rely on randomization techniques.',
+      data.projects[2]
+    ),
   ]
 
   data.chats = [

--- a/server/src/data/projects/erp-rollout.md
+++ b/server/src/data/projects/erp-rollout.md
@@ -1,0 +1,3 @@
+# ERP Roll-out
+
+Detailed plan for deploying the new enterprise resource planning system, including change management and training tasks.

--- a/server/src/data/projects/solar-farm-expansion.md
+++ b/server/src/data/projects/solar-farm-expansion.md
@@ -1,0 +1,3 @@
+# Solar Farm Expansion
+
+This project focuses on extending the existing solar farm and details site preparation, procurement steps and risk mitigation strategies.

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -64,6 +64,7 @@ export async function handleProjectRequests(
       nextId,
       'Generated Project',
       'Auto generated project',
+      'Auto generated project',
       0,
       0,
       100,

--- a/shared/models/ChatHandler.ts
+++ b/shared/models/ChatHandler.ts
@@ -71,6 +71,7 @@ export class ChatHandler {
           new Project(
             c.topic.project.id,
             c.topic.project.name,
+            c.topic.project.shortDescription,
             c.topic.project.description,
             c.topic.project.start,
             c.topic.project.current,

--- a/shared/models/ChatHandler.ts
+++ b/shared/models/ChatHandler.ts
@@ -6,6 +6,7 @@ import { Goal } from './Goal'
 interface TopicDTO {
   id: number
   name: string
+  shortDescription: string
   project: {
     id: number
     name: string
@@ -68,6 +69,7 @@ export class ChatHandler {
         new Topic(
           c.topic.id,
           c.topic.name,
+          c.topic.shortDescription,
           new Project(
             c.topic.project.id,
             c.topic.project.name,

--- a/shared/models/Project.ts
+++ b/shared/models/Project.ts
@@ -5,6 +5,7 @@ import { APP_CONFIG } from "../utils/appConfig";
 export class Project {
   id: number;
   name: string;
+  shortDescription: string;
   description: string;
   start: number;
   current: number;
@@ -27,10 +28,21 @@ export class Project {
      * @param status - Current status of the project.
      * @param goal - Associated goal for the project.
      */
-    constructor(id: number, name: string, description: string, start: number, current: number,
-                objective: number, period: [Date, Date], goal: Goal, contributionPct: number) {
+    constructor(
+        id: number,
+        name: string,
+        shortDescription: string,
+        description: string,
+        start: number,
+        current: number,
+        objective: number,
+        period: [Date, Date],
+        goal: Goal,
+        contributionPct: number
+    ) {
         this.id = id;
         this.name = name;
+        this.shortDescription = shortDescription;
         this.description = description;
         this.start = start;
         this.current = current;

--- a/shared/models/ProjectHandler.test.ts
+++ b/shared/models/ProjectHandler.test.ts
@@ -14,7 +14,18 @@ function createGoal(id: number): Goal {
 }
 
 function createProject(id: number, goal: Goal): Project {
-  return new Project(id, `p${id}`, '', 0, 0, 1, [new Date(), new Date()], goal, 10)
+  return new Project(
+    id,
+    `p${id}`,
+    '',
+    '',
+    0,
+    0,
+    1,
+    [new Date(), new Date()],
+    goal,
+    10,
+  )
 }
 
 test('createProject adds a project', async () => {

--- a/shared/models/ProjectHandler.ts
+++ b/shared/models/ProjectHandler.ts
@@ -72,6 +72,7 @@ export class ProjectHandler {
         new Project(
           p.id,
           p.name,
+          p.shortDescription,
           p.description,
           p.start,
           p.current,
@@ -101,6 +102,7 @@ export class ProjectHandler {
         new Project(
           p.id,
           p.name,
+          p.shortDescription,
           p.description,
           p.start,
           p.current,
@@ -136,6 +138,7 @@ export class ProjectHandler {
       new Project(
         p.id,
         p.name,
+        p.shortDescription,
         p.description,
         p.start,
         p.current,

--- a/shared/models/TaskHandler.ts
+++ b/shared/models/TaskHandler.ts
@@ -34,6 +34,7 @@ export class TaskHandler {
         new Project(
           t.project.id,
           t.project.name,
+          t.project.shortDescription,
           t.project.description,
           t.project.start,
           t.project.current,
@@ -74,6 +75,7 @@ export class TaskHandler {
         new Project(
           t.project.id,
           t.project.name,
+          t.project.shortDescription,
           t.project.description,
           t.project.start,
           t.project.current,

--- a/shared/models/Topic.ts
+++ b/shared/models/Topic.ts
@@ -3,11 +3,13 @@ import { Project } from './Project'
 export class Topic {
   id: number
   name: string
+  shortDescription: string
   project: Project
 
-  constructor(id: number, name: string, project: Project) {
+  constructor(id: number, name: string, shortDescription: string, project: Project) {
     this.id = id
     this.name = name
+    this.shortDescription = shortDescription
     this.project = project
   }
 }

--- a/shared/models/TopicHandler.ts
+++ b/shared/models/TopicHandler.ts
@@ -58,6 +58,7 @@ export class TopicHandler {
         new Project(
           t.project.id,
           t.project.name,
+          t.project.shortDescription,
           t.project.description,
           t.project.start,
           t.project.current,

--- a/shared/models/TopicHandler.ts
+++ b/shared/models/TopicHandler.ts
@@ -5,6 +5,7 @@ import { Goal } from './Goal'
 interface TopicDTO {
   id: number
   name: string
+  shortDescription: string
   project: {
     id: number
     name: string
@@ -55,6 +56,7 @@ export class TopicHandler {
       new Topic(
         t.id,
         t.name,
+        t.shortDescription,
         new Project(
           t.project.id,
           t.project.name,


### PR DESCRIPTION
## Summary
- store shortDescription on Project model
- use short description in ProjectPage cards
- collect short description in AddProjectModal
- load detailed project markdown from new sample files
- adapt handlers to map the new field
- show message when no topics exist in TopicTab

## Testing
- `npm run lint` *(fails: 288 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684be57485ac832bbaa90c2dc6505ae1