### PR TITLE
Fix width of overview tabs

### DIFF
--- a/app/src/components/views/GoalDetailView.tsx
+++ b/app/src/components/views/GoalDetailView.tsx
@@ -94,8 +94,10 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
   const TabButton: React.FC<TabButtonProps> = ({ tabId, label, icon: Icon }) => (
     <button
       onClick={() => setActiveTab(tabId)}
-      className={`flex flex-shrink-0 items-center px-4 py-2 text-sm font-medium rounded-md transition ${
-        activeTab === tabId ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+      className={`flex flex-1 flex-shrink-0 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
+        activeTab === tabId
+          ? 'bg-blue-100 text-blue-700'
+          : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
       }`}
     >
       <Icon size={18} className="mr-2" />

--- a/app/src/components/views/ProjectDetailView.tsx
+++ b/app/src/components/views/ProjectDetailView.tsx
@@ -51,8 +51,10 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({ project, onBack }
   const TabButton: React.FC<TabButtonProps> = ({ tabId, label, icon: Icon }) => (
     <button
       onClick={() => setActiveTab(tabId)}
-      className={`flex flex-shrink-0 items-center px-4 py-2 text-sm font-medium rounded-md transition ${
-        activeTab === tabId ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+      className={`flex flex-1 flex-shrink-0 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
+        activeTab === tabId
+          ? 'bg-blue-100 text-blue-700'
+          : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
       }`}
     >
       <Icon size={18} className="mr-2" />


### PR DESCRIPTION
## Summary
- ensure overview tab buttons stretch evenly for projects and goals

## Testing
- `npm run lint` *(fails: 289 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684bf127501c832baf88a8f51d35e0a8