### PR TITLE
Add automated task support with timeline

### DIFF
--- a/app/src/components/tabs/goal/OverviewTab.tsx
+++ b/app/src/components/tabs/goal/OverviewTab.tsx
@@ -88,7 +88,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ goal }) => {
   } : null;
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       <div className="bg-white shadow rounded p-4 flex flex-col items-center">
         <h3 className="text-sm font-semibold mb-2">Overall Progress</h3>
         <Doughnut data={progressData} className="max-w-xs" />

--- a/app/src/components/tabs/goal/OverviewTab.tsx
+++ b/app/src/components/tabs/goal/OverviewTab.tsx
@@ -88,7 +88,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ goal }) => {
   } : null;
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       <div className="bg-white shadow rounded p-4 flex flex-col items-center">
         <h3 className="text-sm font-semibold mb-2">Overall Progress</h3>
         <Doughnut data={progressData} className="max-w-xs" />

--- a/app/src/components/tabs/goal/OverviewTab.tsx
+++ b/app/src/components/tabs/goal/OverviewTab.tsx
@@ -88,7 +88,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ goal }) => {
   } : null;
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       <div className="bg-white shadow rounded p-4 flex flex-col items-center">
         <h3 className="text-sm font-semibold mb-2">Overall Progress</h3>
         <Doughnut data={progressData} className="max-w-xs" />

--- a/app/src/components/tabs/project/TaskTab.tsx
+++ b/app/src/components/tabs/project/TaskTab.tsx
@@ -59,7 +59,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ project }) => {
                 task instanceof AutomatedTask
                   ? automationStyle[task.status]
                   : manualStyle
-              } p-3 rounded-md flex justify-between items-start sm:items-center gap-2`}
+              } p-3 rounded-md flex justify-between items-center gap-2`}
             >
               <div className="flex-1">
                 <p className="font-medium text-sm text-gray-800">{task.name}</p>

--- a/app/src/components/tabs/project/TaskTab.tsx
+++ b/app/src/components/tabs/project/TaskTab.tsx
@@ -1,10 +1,18 @@
 import React, { useEffect, useState } from 'react'
 import { Project } from '@shared/models/Project'
-import { Task, ManualTask, AutomatedTask } from '@shared/models/Task'
+import { Task, ManualTask, AutomatedTask, AutomationState } from '@shared/models/Task'
 import { TaskHandler } from '@shared/models/TaskHandler'
 import { Sparkles } from 'lucide-react'
 import { Timeline } from '@/components/ui/timeline'
 import { StatusIndicator } from '@/components/ui/status-indicator'
+
+const manualStyle = 'bg-blue-50 border border-blue-200'
+const automationStyle: Record<AutomationState, string> = {
+  running: 'bg-green-50 border border-green-200',
+  attention: 'bg-orange-50 border border-orange-200',
+  not_started: 'bg-gray-50 border border-gray-200',
+  failed: 'bg-red-50 border border-red-200',
+}
 
 interface TaskTabProps {
   project: Project
@@ -47,11 +55,17 @@ const TaskTab: React.FC<TaskTabProps> = ({ project }) => {
           {tasks.map(task => (
             <li
               key={task.id}
-              className="bg-blue-50 border border-blue-200 p-3 rounded-md flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2"
+              className={`${
+                task instanceof AutomatedTask
+                  ? automationStyle[task.status]
+                  : manualStyle
+              } p-3 rounded-md flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2`}
             >
               <div>
                 <p className="font-medium text-sm text-gray-800">{task.name}</p>
-                <p className="text-xs text-gray-600">{task.description}</p>
+                {task.completedAt && (
+                  <p className="text-xs text-gray-600">{task.description}</p>
+                )}
                 <p className="text-xs text-gray-600">Due {task.deadline.toLocaleDateString()}</p>
                 <p className="text-xs text-gray-500">Duration {(task.duration / 3600).toFixed(1)}h</p>
               </div>

--- a/app/src/components/tabs/project/TaskTab.tsx
+++ b/app/src/components/tabs/project/TaskTab.tsx
@@ -59,11 +59,11 @@ const TaskTab: React.FC<TaskTabProps> = ({ project }) => {
                 task instanceof AutomatedTask
                   ? automationStyle[task.status]
                   : manualStyle
-              } p-3 rounded-md flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2`}
+              } p-3 rounded-md flex justify-between items-start sm:items-center gap-2`}
             >
-              <div>
+              <div className="flex-1">
                 <p className="font-medium text-sm text-gray-800">{task.name}</p>
-                {task.completedAt && (
+                {task.completedAt && !(task instanceof ManualTask) && (
                   <p className="text-xs text-gray-600">{task.description}</p>
                 )}
                 <p className="text-xs text-gray-600">Due {task.deadline.toLocaleDateString()}</p>

--- a/app/src/components/tabs/project/TaskTab.tsx
+++ b/app/src/components/tabs/project/TaskTab.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import { Project } from '@shared/models/Project'
-import { Task } from '@shared/models/Task'
+import { Task, ManualTask, AutomatedTask } from '@shared/models/Task'
 import { TaskHandler } from '@shared/models/TaskHandler'
 import { Sparkles } from 'lucide-react'
+import { Timeline } from '@/components/ui/timeline'
+import { StatusIndicator } from '@/components/ui/status-indicator'
 
 interface TaskTabProps {
   project: Project
@@ -48,29 +50,44 @@ const TaskTab: React.FC<TaskTabProps> = ({ project }) => {
               className="bg-blue-50 border border-blue-200 p-3 rounded-md flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2"
             >
               <div>
-                <p className="font-medium text-sm text-gray-800">{task.description}</p>
+                <p className="font-medium text-sm text-gray-800">{task.name}</p>
+                <p className="text-xs text-gray-600">{task.description}</p>
                 <p className="text-xs text-gray-600">Due {task.deadline.toLocaleDateString()}</p>
                 <p className="text-xs text-gray-500">Duration {(task.duration / 3600).toFixed(1)}h</p>
               </div>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  className="p-1 rounded-full bg-blue-600 text-white hover:bg-blue-700"
-                >
-                  <Sparkles size={16} />
-                </button>
-                <button
-                  type="button"
-                  className="p-1 rounded-full bg-blue-600 text-white hover:bg-blue-700"
-                >
-                  <Sparkles size={16} />
-                </button>
+              <div className="flex gap-2 items-center">
+                {task instanceof ManualTask && (
+                  <button
+                    type="button"
+                    className="p-1 rounded-full bg-blue-600 text-white hover:bg-blue-700"
+                  >
+                    <Sparkles size={16} />
+                  </button>
+                )}
+                {task instanceof AutomatedTask && (
+                  <StatusIndicator status={task.status} />
+                )}
               </div>
             </li>
           ))}
         </ul>
       ) : (
         <p className="text-gray-500 italic text-sm">No tasks for this project.</p>
+      )}
+
+      {tasks.some(t => t.completedAt) && (
+        <div>
+          <h5 className="text-md font-semibold text-gray-700 mt-4">Timeline</h5>
+          <Timeline
+            entries={tasks
+              .filter(t => t.completedAt)
+              .map(t => ({
+                title: t.name,
+                description: t.description,
+                date: t.completedAt!.toLocaleDateString(),
+              }))}
+          />
+        </div>
       )}
     </div>
   )

--- a/app/src/components/ui/timeline.tsx
+++ b/app/src/components/ui/timeline.tsx
@@ -15,9 +15,10 @@ interface TimelineProps {
 
 export const Timeline: React.FC<TimelineProps> = ({ entries }) => {
   return (
-    <ol className="relative border-s border-gray-200 dark:border-gray-700">
-      {entries.map((entry, idx) => (
-        <li key={idx} className="mb-10 ms-6">
+    <div>
+      <ol className="relative border-s border-gray-200 dark:border-gray-700">
+        {entries.map((entry, idx) => (
+          <li key={idx} className="mb-10 ms-6">
           <span className="absolute flex items-center justify-center w-6 h-6 bg-blue-100 rounded-full -start-3 ring-8 ring-white dark:ring-gray-900 dark:bg-blue-900">
             <svg
               className="w-2.5 h-2.5 text-blue-800 dark:text-blue-300"
@@ -55,6 +56,7 @@ export const Timeline: React.FC<TimelineProps> = ({ entries }) => {
           )}
         </li>
       ))}
-    </ol>
+      </ol>
+    </div>
   );
 };

--- a/server/src/data/data.ts
+++ b/server/src/data/data.ts
@@ -9,7 +9,7 @@ import path from 'node:path'
 import { Goal } from '../../../shared/models/Goal'
 import { Project } from '../../../shared/models/Project'
 import { Document } from '../../../shared/models/Document'
-import { Task } from '../../../shared/models/Task'
+import { Task, ManualTask, AutomatedTask, AutomationState } from '../../../shared/models/Task'
 import { Topic } from '../../../shared/models/Topic'
 import { Chat } from '../../../shared/models/Chat'
 import { AOL } from '../../../shared/types/AOL'
@@ -120,13 +120,60 @@ export function initData(): void {
   ]
 
   data.tasks = [
-    new Task(
+    new ManualTask(
       1,
       'Initial planning',
+      'Plan the overall project steps',
       new Date('2025-01-15'),
       data.projects[0],
       3600
     ),
+    new ManualTask(
+      2,
+      'Read papers',
+      'Review key research papers',
+      new Date('2024-09-10'),
+      data.projects[2],
+      7200,
+      [],
+      new Date('2024-09-12')
+    ),
+    new AutomatedTask(
+      3,
+      'Dataset preprocessing',
+      'Run preprocessing pipeline',
+      new Date('2024-09-12'),
+      data.projects[2],
+      5400,
+      'running'
+    ),
+    new AutomatedTask(
+      4,
+      'Model tuning',
+      'Automated hyperparameter tuning',
+      new Date('2024-10-01'),
+      data.projects[2],
+      5400,
+      'attention'
+    ),
+    new AutomatedTask(
+      5,
+      'Result compilation',
+      'Compile algorithm benchmarks',
+      new Date('2024-11-01'),
+      data.projects[2],
+      3600,
+      'failed'
+    ),
+    new AutomatedTask(
+      6,
+      'Generate report',
+      'Create final report automatically',
+      new Date('2024-12-01'),
+      data.projects[2],
+      7200,
+      'not_started'
+    )
   ]
 
   data.documents = [

--- a/server/src/data/data.ts
+++ b/server/src/data/data.ts
@@ -138,6 +138,14 @@ export function initData(): void {
       [],
       new Date('2024-09-12')
     ),
+    new ManualTask(
+      7,
+      'Prepare slides',
+      'Draft presentation slides',
+      new Date('2024-10-10'),
+      data.projects[2],
+      5400
+    ),
     new AutomatedTask(
       3,
       'Dataset preprocessing',

--- a/server/src/data/data.ts
+++ b/server/src/data/data.ts
@@ -181,6 +181,36 @@ export function initData(): void {
       data.projects[2],
       7200,
       'not_started'
+    ),
+    new ManualTask(
+      8,
+      'Select paper topics',
+      'Choose seminar paper topics',
+      new Date('2024-09-05'),
+      data.projects[2],
+      1800,
+      [],
+      new Date('2024-09-05')
+    ),
+    new ManualTask(
+      9,
+      'Submit paper summary',
+      'Write summary for selected paper',
+      new Date('2024-09-15'),
+      data.projects[2],
+      3600,
+      [],
+      new Date('2024-09-16')
+    ),
+    new ManualTask(
+      10,
+      'Complete exercises',
+      'Solve algorithm practice problems',
+      new Date('2024-09-20'),
+      data.projects[2],
+      5400,
+      [],
+      new Date('2024-09-21')
     )
   ]
 

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -1,7 +1,7 @@
 import http from 'node:http'
 import { parseBody } from '../utils'
 import { data } from '../data/data'
-import { Task } from '../../../shared/models/Task'
+import { Task, ManualTask } from '../../../shared/models/Task'
 
 /**
  * Handles `/tasks` routes. Returns `true` if a request is processed.
@@ -45,7 +45,14 @@ export async function handleTaskRequests(
     const nextId = data.tasks.length
       ? Math.max(...data.tasks.map(t => t.id)) + 1
       : 1
-    const task = new Task(nextId, 'Generated Task', project.period[1], project, 3600)
+    const task = new ManualTask(
+      nextId,
+      'Generated Task',
+      'Generated task description',
+      project.period[1],
+      project,
+      3600
+    )
     data.tasks.push(task)
     res.statusCode = 201
     res.setHeader('Content-Type', 'application/json')

--- a/shared/models/Task.ts
+++ b/shared/models/Task.ts
@@ -2,11 +2,13 @@ import { Project } from './Project'
 
 export class Task {
   id: number
+  name: string
   description: string
   deadline: Date
   project: Project
   duration: number
   dependencies: Task[]
+  completedAt?: Date | null
     /**
      * Creates a new Task instance.
      * @param id - Unique identifier for the task.
@@ -16,13 +18,24 @@ export class Task {
      * @param duration - Estimated duration of the task in seconds.
      * @param dependencies - List of tasks that this task depends on.
     */
-    constructor(id: number, description: string, deadline: Date, project: Project, duration: number, dependencies: Task[] = []) {
+    constructor(
+        id: number,
+        name: string,
+        description: string,
+        deadline: Date,
+        project: Project,
+        duration: number,
+        dependencies: Task[] = [],
+        completedAt: Date | null = null
+    ) {
         this.id = id;
+        this.name = name;
         this.description = description;
         this.deadline = deadline;
         this.project = project;
         this.duration = duration;
         this.dependencies = dependencies;
+        this.completedAt = completedAt;
     }
 
     /**
@@ -30,6 +43,29 @@ export class Task {
      * @returns A string describing the task.
     */
     toString(): string {
-        return `Task[${this.id}]: ${this.description} (Deadline: ${this.deadline.toISOString()}, Project: ${this.project.name}, Duration: ${this.duration}s, Dependencies: [${this.dependencies.map(d => d.id).join(', ')}])`;
+        return `Task[${this.id} ${this.name}]: ${this.description} (Deadline: ${this.deadline.toISOString()}, Project: ${this.project.name}, Duration: ${this.duration}s, Dependencies: [${this.dependencies.map(d => d.id).join(', ')}], Completed: ${this.completedAt ? this.completedAt.toISOString() : 'n/a'})`;
+    }
+}
+
+export class ManualTask extends Task {}
+
+export type AutomationState = 'running' | 'attention' | 'not_started' | 'failed'
+
+export class AutomatedTask extends Task {
+    status: AutomationState
+
+    constructor(
+        id: number,
+        name: string,
+        description: string,
+        deadline: Date,
+        project: Project,
+        duration: number,
+        status: AutomationState,
+        dependencies: Task[] = [],
+        completedAt: Date | null = null
+    ) {
+        super(id, name, description, deadline, project, duration, dependencies, completedAt)
+        this.status = status
     }
 }

--- a/shared/models/TaskHandler.ts
+++ b/shared/models/TaskHandler.ts
@@ -1,4 +1,4 @@
-import { Task } from './Task'
+import { Task, AutomatedTask, ManualTask, AutomationState } from './Task'
 import { Project } from './Project'
 import { Goal } from './Goal'
 
@@ -26,12 +26,8 @@ export class TaskHandler {
     const res = await fetch(`${this.baseUrl}/tasks?projectId=${projectId}`)
     if (!res.ok) return []
     const data = await res.json()
-    return data.map((t: any) =>
-      new Task(
-        t.id,
-        t.description,
-        new Date(t.deadline),
-        new Project(
+    return data.map((t: any) => {
+      const project = new Project(
           t.project.id,
           t.project.name,
           t.project.shortDescription,
@@ -51,10 +47,32 @@ export class TaskHandler {
             t.project.goal.aol
           ),
           t.project.contributionPct
-        ),
-        t.duration
-      )
-    )
+        )
+      const common = [
+        t.id,
+        t.name,
+        t.description,
+        new Date(t.deadline),
+        project,
+        t.duration,
+        [],
+        t.completedAt ? new Date(t.completedAt) : null
+      ] as const
+      if (t.status) {
+        return new AutomatedTask(
+          common[0],
+          common[1],
+          common[2],
+          common[3],
+          common[4],
+          common[5],
+          t.status as AutomationState,
+          common[6],
+          common[7]
+        )
+      }
+      return new ManualTask(...common)
+    })
   }
 
   async generateTasks(projectId: number): Promise<Task[]> {
@@ -67,34 +85,53 @@ export class TaskHandler {
       throw new Error('Failed to generate tasks')
     }
     const data = await res.json()
-    const map = (t: any) =>
-      new Task(
+    const map = (t: any) => {
+      const project = new Project(
+        t.project.id,
+        t.project.name,
+        t.project.shortDescription,
+        t.project.description,
+        t.project.start,
+        t.project.current,
+        t.project.objective,
+        [new Date(t.project.period[0]), new Date(t.project.period[1])],
+        new Goal(
+          t.project.goal.id,
+          t.project.goal.name,
+          t.project.goal.description,
+          t.project.goal.start,
+          t.project.goal.current,
+          t.project.goal.objective,
+          [new Date(t.project.goal.period[0]), new Date(t.project.goal.period[1])],
+          t.project.goal.aol
+        ),
+        t.project.contributionPct
+      )
+      const common = [
         t.id,
+        t.name,
         t.description,
         new Date(t.deadline),
-        new Project(
-          t.project.id,
-          t.project.name,
-          t.project.shortDescription,
-          t.project.description,
-          t.project.start,
-          t.project.current,
-          t.project.objective,
-          [new Date(t.project.period[0]), new Date(t.project.period[1])],
-          new Goal(
-            t.project.goal.id,
-            t.project.goal.name,
-            t.project.goal.description,
-            t.project.goal.start,
-            t.project.goal.current,
-            t.project.goal.objective,
-            [new Date(t.project.goal.period[0]), new Date(t.project.goal.period[1])],
-            t.project.goal.aol
-          ),
-          t.project.contributionPct
-        ),
-        t.duration
-      )
+        project,
+        t.duration,
+        [],
+        t.completedAt ? new Date(t.completedAt) : null
+      ] as const
+      if (t.status) {
+        return new AutomatedTask(
+          common[0],
+          common[1],
+          common[2],
+          common[3],
+          common[4],
+          common[5],
+          t.status as AutomationState,
+          common[6],
+          common[7]
+        )
+      }
+      return new ManualTask(...common)
+    }
     return Array.isArray(data) ? data.map(map) : [map(data)]
   }
 }


### PR DESCRIPTION
## Summary
- tweak goal overview layout so it matches other tabs
- split tasks into `ManualTask` and `AutomatedTask`
- show automation status and task timeline in project view
- extend task handler and seed data for new task types

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c03080dd8832b9ce19683c09a0b9c