### PR TITLE
Implement manual task completion

### DIFF
--- a/app/src/components/tabs/project/TaskTab.tsx
+++ b/app/src/components/tabs/project/TaskTab.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Project } from '@shared/models/Project'
 import { Task, ManualTask, AutomatedTask, AutomationState } from '@shared/models/Task'
 import { TaskHandler } from '@shared/models/TaskHandler'
-import { Check, Sparkles } from 'lucide-react'
+import { Check, Sparkles, ChevronDown, ChevronUp } from 'lucide-react'
 import { Timeline } from '@/components/ui/timeline'
 import { StatusIndicator } from '@/components/ui/status-indicator'
 import Modal from '@/components/ui/modal'
@@ -25,6 +25,7 @@ interface TaskTabProps {
 const TaskTab: React.FC<TaskTabProps> = ({ project }) => {
   const [tasks, setTasks] = useState<Task[]>([])
   const [activeChat, setActiveChat] = useState<Chat | null>(null)
+  const [showTimeline, setShowTimeline] = useState(true)
   const handler = React.useMemo(() => TaskHandler.getInstance(), [])
 
   const sortTasks = (list: Task[]) =>
@@ -126,19 +127,28 @@ const TaskTab: React.FC<TaskTabProps> = ({ project }) => {
 
       {tasks.some(t => t.completedAt) && (
         <div>
-          <h5 className="text-md font-semibold text-gray-700 mt-4">Timeline</h5>
-          <Timeline
-            entries={tasks
-              .filter(t => t.completedAt)
-              .sort((a, b) =>
-                b.completedAt!.getTime() - a.completedAt!.getTime()
-              )
-              .map(t => ({
-                title: t.name,
-                description: t.description,
-                date: t.completedAt!.toLocaleDateString(),
-              }))}
-          />
+          <button
+            type="button"
+            onClick={() => setShowTimeline(v => !v)}
+            className="flex items-center justify-between w-full mt-4"
+          >
+            <h5 className="text-md font-semibold text-gray-700">Timeline</h5>
+            {showTimeline ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+          </button>
+          {showTimeline && (
+            <Timeline
+              entries={tasks
+                .filter(t => t.completedAt)
+                .sort((a, b) =>
+                  b.completedAt!.getTime() - a.completedAt!.getTime()
+                )
+                .map(t => ({
+                  title: t.name,
+                  description: t.description,
+                  date: t.completedAt!.toLocaleDateString(),
+                }))}
+            />
+          )}
         </div>
       )}
 

--- a/app/src/components/tabs/project/TaskTab.tsx
+++ b/app/src/components/tabs/project/TaskTab.tsx
@@ -130,9 +130,9 @@ const TaskTab: React.FC<TaskTabProps> = ({ project }) => {
           <button
             type="button"
             onClick={() => setShowTimeline(v => !v)}
-            className="flex items-center justify-between w-full mt-4"
+            className="flex items-center justify-between mt-4"
           >
-            <h5 className="text-md font-semibold text-gray-700">Timeline</h5>
+            <h5 className="text-md font-semibold text-gray-700">Finished Tasks</h5>
             {showTimeline ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
           </button>
           {showTimeline && (

--- a/app/src/components/tabs/project/TaskTab.tsx
+++ b/app/src/components/tabs/project/TaskTab.tsx
@@ -76,9 +76,11 @@ const TaskTab: React.FC<TaskTabProps> = ({ project }) => {
           <Sparkles size={16} className="mr-1 sm:mr-2" /> Generate Tasks
         </button>
       </div>
-      {tasks.length > 0 ? (
+      {tasks.filter(t => !t.completedAt).length > 0 ? (
         <ul className="space-y-2">
-          {tasks.map(task => (
+          {tasks
+            .filter(t => !t.completedAt)
+            .map(task => (
             <li
               key={task.id}
               onClick={() => openTask(task)}


### PR DESCRIPTION
## Summary
- finish manual tasks via button
- open chat modal when clicking any task
- sort tasks by date and show a chronological timeline

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c12331d5c832bbd67773771077bcc