### PR TITLE
Fix inline code styling

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="h-full">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lifemanager</title>
   </head>
-  <body>
-    <div id="root"></div>
+  <body class="h-full">
+    <div id="root" class="h-full"></div>
     <script type="module" src="/src/main.tsx"></script>
     <script src="../node_modules/flowbite/dist/flowbite.min.js"></script>
     <!-- MathJax for rendering LaTeX in markdown -->

--- a/app/src/components/ui/app-shell.tsx
+++ b/app/src/components/ui/app-shell.tsx
@@ -15,7 +15,7 @@ function ShellInner({ children }: { children: React.ReactNode }) {
   const { activeTab, setActiveTab, isSidebarOpen, setIsSidebarOpen } = useAppShell();
 
   return (
-    <div className="relative min-h-screen md:flex">
+    <div className="relative h-screen flex flex-col md:flex-row overflow-hidden">
       {/* ----- mobile top bar ----- */}
       <div className="md:hidden flex justify-between items-center p-4 bg-white border-b sticky top-0 z-20">
         <h1 className="text-lg font-bold text-blue-700">Lifemanager</h1>
@@ -97,7 +97,7 @@ function ShellInner({ children }: { children: React.ReactNode }) {
       </nav>
 
       {/* ----- main area ----- */}
-      <main className="flex-1 bg-gray-50 overflow-y-auto pt-16 md:pt-0">{children}</main>
+      <main className="flex-1 h-full bg-gray-50 overflow-y-auto pt-16 md:pt-0">{children}</main>
     </div>
   );
 }

--- a/app/src/pages/Page.tsx
+++ b/app/src/pages/Page.tsx
@@ -9,7 +9,7 @@ ProjectHandler.getInstance(goals);
 export default function Home() {
 /* ---------- single source of truth for client list ---------- */
   return (
-    <div className="min-h-screen bg-gray-100 p-4 md:p-8 font-sans">
+    <div className="h-full overflow-y-auto bg-gray-100 p-4 md:p-8 font-sans">
       <main className="container mx-auto max-w-7xl space-y-8">
         <DashboardContent />
       </main>

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -84,4 +84,9 @@ body {
   body {
     @apply bg-background text-foreground;
   }
+  /* Remove backticks around inline code produced by the typography plugin */
+  .prose code::before,
+  .prose code::after {
+    content: '';
+  }
 }

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -81,12 +81,17 @@ body {
   * {
     @apply border-border;
   }
+  html,
+  body,
+  #root {
+    @apply h-full;
+  }
   body {
     @apply bg-background text-foreground;
   }
   /* Remove backticks around inline code produced by the typography plugin */
   .prose code::before,
   .prose code::after {
-    content: '';
+    content: none;
   }
 }

--- a/app/tailwind.config.ts
+++ b/app/tailwind.config.ts
@@ -9,9 +9,17 @@ export default {
     "./src/styles/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-  	extend: {
-  		colors: {
-  			background: 'hsl(var(--background))',
+        extend: {
+                typography: {
+                        DEFAULT: {
+                                css: {
+                                        'code::before': { content: 'none' },
+                                        'code::after': { content: 'none' },
+                                },
+                        },
+                },
+                colors: {
+                        background: 'hsl(var(--background))',
   			foreground: 'hsl(var(--foreground))',
   			card: {
   				DEFAULT: 'hsl(var(--card))',


### PR DESCRIPTION
## Summary
- ensure inline code doesn't show backticks
- keep pages within viewport height

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_684c3e820d7c832b8b5a52b9c3ef56ff