### PR TITLE
Add Supabase auth flow

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import { useAuth } from '@/hooks/use-auth'
+import RootLayout from '@/components/RootLayout'
+import Home from '@/pages/Page'
+import LoginPage from '@/pages/LoginPage'
+import RegisterPage from '@/pages/RegisterPage'
+
+export default function App() {
+  const { session } = useAuth()
+  const [view, setView] = useState<'login' | 'register'>('login')
+
+  if (!session) {
+    return view === 'login' ? (
+      <LoginPage onShowRegister={() => setView('register')} />
+    ) : (
+      <RegisterPage onShowLogin={() => setView('login')} />
+    )
+  }
+
+  return (
+    <RootLayout>
+      <Home />
+    </RootLayout>
+  )
+}

--- a/app/src/components/ui/app-shell.tsx
+++ b/app/src/components/ui/app-shell.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { Button } from '@/components/ui/button';
 import { Menu, X, LogOut, ListTodo, Settings, Target, Repeat, Home } from 'lucide-react';
+import { supabase } from '@/lib/supabaseClient';
 import { AppShellProvider, useAppShell } from './app-shell-context';
 
 /* ----- icons mapping for sidebar items ----- */
@@ -89,7 +90,10 @@ function ShellInner({ children }: { children: React.ReactNode }) {
             <Settings className="w-5 h-5 mr-3" />
             Einstellungen
           </button>
-          <button className="w-full flex items-center px-3 py-2.5 rounded-md text-sm text-gray-600 hover:bg-gray-100">
+          <button
+            onClick={() => supabase.auth.signOut()}
+            className="w-full flex items-center px-3 py-2.5 rounded-md text-sm text-gray-600 hover:bg-gray-100"
+          >
             <LogOut className="w-5 h-5 mr-3" />
             Ausloggen
           </button>

--- a/app/src/hooks/use-auth.tsx
+++ b/app/src/hooks/use-auth.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+import { Session } from '@supabase/supabase-js'
+import { supabase } from '@/lib/supabaseClient'
+
+interface AuthState {
+  session: Session | null
+}
+
+const AuthContext = createContext<AuthState>({ session: null })
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session))
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+    return () => {
+      listener.subscription.unsubscribe()
+    }
+  }, [])
+
+  return <AuthContext.Provider value={{ session }}>{children}</AuthContext.Provider>
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/app/src/lib/supabaseClient.ts
+++ b/app/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/app/src/lib/supabaseClient.ts
+++ b/app/src/lib/supabaseClient.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
+const supabaseUrl = import.meta.env.SUPABASE_URL as string
+const supabaseAnonKey = import.meta.env.ANON_KEY as string
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/app/src/lib/supabaseClient.ts
+++ b/app/src/lib/supabaseClient.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = import.meta.env.SUPABASE_URL as string
-const supabaseAnonKey = import.meta.env.ANON_KEY as string
+const supabaseUrl = import.meta.env.SUPABASE_URL
+const supabaseAnonKey = import.meta.env.ANON_KEY
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase = createClient("https://sb.nickzerjeski.me", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE")

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import Home from './pages/Page';
-import RootLayout from './components/RootLayout';
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { AuthProvider } from './hooks/use-auth'
+import App from './App'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <RootLayout>
-      <Home />
-    </RootLayout>
-  </React.StrictMode>,
-);
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </React.StrictMode>
+)

--- a/app/src/pages/LoginPage.tsx
+++ b/app/src/pages/LoginPage.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { supabase } from '@/lib/supabaseClient'
+
+interface Props {
+  onShowRegister: () => void
+}
+
+export default function LoginPage({ onShowRegister }: Props) {
+  const form = useForm({ defaultValues: { email: '', password: '' } })
+  const [error, setError] = useState<string | null>(null)
+
+  async function onSubmit(values: { email: string; password: string }) {
+    setError(null)
+    const { error } = await supabase.auth.signInWithPassword(values)
+    if (error) setError(error.message)
+  }
+
+  return (
+    <div className="h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white shadow rounded p-6 w-full max-w-md space-y-4">
+        <h1 className="text-xl font-bold">Login</h1>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="email"
+              rules={{ required: 'Email required' }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input type="email" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="password"
+              rules={{ required: 'Password required' }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input type="password" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <Button type="submit" className="w-full">Sign In</Button>
+          </form>
+        </Form>
+        <p className="text-sm">
+          Don't have an account?{' '}
+          <button onClick={onShowRegister} className="text-blue-600 hover:underline" type="button">
+            Register
+          </button>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/src/pages/RegisterPage.tsx
+++ b/app/src/pages/RegisterPage.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { supabase } from '@/lib/supabaseClient'
+
+interface Props {
+  onShowLogin: () => void
+}
+
+export default function RegisterPage({ onShowLogin }: Props) {
+  const form = useForm({ defaultValues: { name: '', email: '', password: '', confirm: '' } })
+  const [error, setError] = useState<string | null>(null)
+
+  function valid(pw: string) {
+    return pw.length >= 8 && /\d/.test(pw)
+  }
+
+  async function onSubmit(values: { name: string; email: string; password: string; confirm: string }) {
+    setError(null)
+    if (values.password !== values.confirm) {
+      setError('Passwords do not match')
+      return
+    }
+    if (!valid(values.password)) {
+      setError('Password must be at least 8 characters and include a number')
+      return
+    }
+    const { error } = await supabase.auth.signUp({
+      email: values.email,
+      password: values.password,
+      options: {
+        data: { name: values.name }
+      }
+    })
+    if (error) setError(error.message)
+  }
+
+  return (
+    <div className="h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white shadow rounded p-6 w-full max-w-md space-y-4">
+        <h1 className="text-xl font-bold">Register</h1>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              rules={{ required: 'Name required' }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="email"
+              rules={{ required: 'Email required' }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input type="email" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="password"
+              rules={{ required: 'Password required' }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input type="password" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="confirm"
+              rules={{ required: 'Confirm your password' }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Confirm Password</FormLabel>
+                  <FormControl>
+                    <Input type="password" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <Button type="submit" className="w-full">Register</Button>
+          </form>
+        </Form>
+        <p className="text-sm">
+          Already have an account?{' '}
+          <button onClick={onShowLogin} className="text-blue-600 hover:underline" type="button">
+            Login
+          </button>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,0 +1,8 @@
+interface ImportMetaEnv {
+  readonly SUPABASE_URL: string
+  readonly ANON_KEY: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -5,6 +5,12 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  optimizeDeps: {
+    include: ['@supabase/supabase-js']
+  },
+  ssr: {
+    noExternal: ['@supabase/supabase-js']
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-toast": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.1.8",
+        "@supabase/supabase-js": "^2.50.0",
         "axios": "^1.9.0",
         "chart.js": "^4.4.9",
         "chartjs-adapter-date-fns": "^3.0.0",
@@ -2915,6 +2916,80 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.70.0.tgz",
+      "integrity": "sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.10",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.10.tgz",
+      "integrity": "sha512-SJKVa7EejnuyfImrbzx+HaD9i6T784khuw1zP+MBD7BmJYChegGxYigPzkKX8CK8nGuDntmeSD3fvriaH0EGZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.50.0.tgz",
+      "integrity": "sha512-M1Gd5tPaaghYZ9OjeO1iORRqbTWFEz/cF3pPubRnMPzA+A8SiUsXXWDP+DWsASZcjEcVEcVQIAF38i5wrijYOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.70.0",
+        "@supabase/functions-js": "2.4.4",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.10",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.9.tgz",
@@ -3347,6 +3422,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -3390,6 +3471,15 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.15.0",
@@ -11176,6 +11266,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
-    "@supabase/supabase-js": "^2.42.0",
+    "@supabase/supabase-js": "^2.50.0",
     "axios": "^1.9.0",
     "chart.js": "^4.4.9",
     "chartjs-adapter-date-fns": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@supabase/supabase-js": "^2.42.0",
     "axios": "^1.9.0",
     "chart.js": "^4.4.9",
     "chartjs-adapter-date-fns": "^3.0.0",

--- a/shared/models/User.ts
+++ b/shared/models/User.ts
@@ -1,0 +1,11 @@
+export class User {
+  id: string
+  email: string
+  name: string
+
+  constructor(id: string, email: string, name: string) {
+    this.id = id
+    this.email = email
+    this.name = name
+  }
+}


### PR DESCRIPTION
## Summary
- add simple User model
- set up Supabase client
- provide AuthProvider hook
- create login and registration pages
- update app entry with auth flow
- enable sign-out through sidebar
- add supabase-js dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: 361 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e9c77f2dc832b9ccd28ea57c23f75