### PR TITLE
Implement supabase document storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ LifeManager accelerates personal goal attainment by turning a high-level aspirat
 ### Document
 - Types accepted: PDF, Markdown, plain text
 - Stored in cloud bucket; metadata keeps `id`, `filename`, `contentType`, and ownership reference
+- Files live in a `documents` bucket structured as:
+  - `documents/<user-id>/<goal-id>/<goal-name>.md`
+  - `documents/<user-id>/<goal-id>/<project-id>/<project-name>.md`
+  - `documents/<user-id>/<goal-id>/<project-id>/<topic-id>/<topic-name>.md`
+  Uploaded files for a goal go under `documents/<user-id>/<goal-id>/` and files for a project under `documents/<user-id>/<goal-id>/<project-id>/`.
 ## AI Pipeline
 1. Trigger – User presses Start Goal; client POSTs `/ai/expand-goal` with goal ID and document references.
 2. Workflow – n8n retrieves documents, feeds cleaned text and metadata to OpenAI.

--- a/shared/models/DocumentHandler.ts
+++ b/shared/models/DocumentHandler.ts
@@ -1,4 +1,14 @@
 import { Document } from './Document'
+import supabase from '../db/supabase'
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  let binary = ''
+  const bytes = new Uint8Array(buffer)
+  bytes.forEach(b => {
+    binary += String.fromCharCode(b)
+  })
+  return btoa(binary)
+}
 
 export class DocumentHandler {
   private static instance: DocumentHandler | null = null
@@ -12,23 +22,95 @@ export class DocumentHandler {
 
   private constructor() {}
 
-  async getDocumentsForGoal(_goalId: string): Promise<Document[]> {
-    return []
+  async getDocumentsForGoal(goalId: string): Promise<Document[]> {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return []
+
+    const { data: goal } = await supabase
+      .from('goals')
+      .select('name')
+      .eq('id', goalId)
+      .single()
+    const path = `${user.id}/${goalId}`
+    const { data: files } = await supabase.storage
+      .from('documents')
+      .list(path)
+    if (!files) return []
+
+    return files
+      .filter(f => !f.name.endsWith('/') && f.name !== `${goal?.name}.md`)
+      .map(f => new Document(
+        `${path}/${f.name}`,
+        { goalId },
+        f.name,
+        f.name.split('.').pop() || '',
+        new Date(f.updated_at || f.created_at || '')
+      ))
   }
 
-  async getDocumentsForProject(_projectId: string): Promise<Document[]> {
-    return []
+  async getDocumentsForProject(projectId: string): Promise<Document[]> {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return []
+
+    const { data: project } = await supabase
+      .from('projects')
+      .select('name, goal_id')
+      .eq('id', projectId)
+      .single()
+    if (!project) return []
+    const path = `${user.id}/${project.goal_id}/${projectId}`
+    const { data: files } = await supabase.storage
+      .from('documents')
+      .list(path)
+    if (!files) return []
+
+    return files
+      .filter(f => !f.name.endsWith('/') && f.name !== `${project.name}.md`)
+      .map(f => new Document(
+        `${path}/${f.name}`,
+        { goalId: project.goal_id, projectId },
+        f.name,
+        f.name.split('.').pop() || '',
+        new Date(f.updated_at || f.created_at || '')
+      ))
   }
 
-  async createDocument(_document: Document): Promise<Document> {
-    return _document
+  async createDocument(document: Document): Promise<Document> {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return document
+    let goalId = document.goalId
+    if (!goalId && document.projectId) {
+      const { data: project } = await supabase
+        .from('projects')
+        .select('goal_id')
+        .eq('id', document.projectId)
+        .single()
+      goalId = project?.goal_id
+    }
+    if (!goalId) return document
+    const path = document.projectId
+      ? `${user.id}/${goalId}/${document.projectId}/${document.name}`
+      : `${user.id}/${goalId}/${document.name}`
+    return new Document(path, { goalId, projectId: document.projectId }, document.name, document.type, document.uploadDate)
   }
 
-  async uploadDocument(_documentId: string, _file: File): Promise<void> {}
-
-  async getDocument(_id: string): Promise<{ name: string; type: string; content: string | null }> {
-    return { name: '', type: '', content: null }
+  async uploadDocument(documentId: string, file: File | Blob): Promise<void> {
+    await supabase.storage.from('documents').upload(documentId, file, { upsert: true })
   }
 
-  async deleteDocument(_id: string): Promise<void> {}
+  async getDocument(id: string): Promise<{ name: string; type: string; content: string | null }> {
+    const { data } = await supabase.storage.from('documents').download(id)
+    if (!data) return { name: '', type: '', content: null }
+    const name = id.split('/').pop() || ''
+    const type = name.split('.').pop() || ''
+    if (type === 'pdf') {
+      const buffer = await data.arrayBuffer()
+      return { name, type, content: arrayBufferToBase64(buffer) }
+    }
+    return { name, type, content: await data.text() }
+  }
+
+  async deleteDocument(id: string): Promise<void> {
+    await supabase.storage.from('documents').remove([id])
+  }
 }

--- a/shared/models/GoalHandler.ts
+++ b/shared/models/GoalHandler.ts
@@ -36,7 +36,8 @@ export class GoalHandler {
       .single()
 
     if (data) {
-      const path = `${user.id}/${data.id}/${data.name}.md`
+      const safeName = encodeURIComponent(data.name)
+      const path = `${user.id}/${data.id}/${safeName}.md`
       const blob = new Blob([
         `# ${data.name}\n\n${data.description || ''}`,
       ], { type: 'text/markdown' })

--- a/shared/models/ProjectHandler.ts
+++ b/shared/models/ProjectHandler.ts
@@ -37,7 +37,8 @@ export class ProjectHandler {
       .single()
 
     if (data) {
-      const path = `${user.id}/${data.goal_id}/${data.id}/${data.name}.md`
+      const safeName = encodeURIComponent(data.name)
+      const path = `${user.id}/${data.goal_id}/${data.id}/${safeName}.md`
       const blob = new Blob([
         `# ${data.name}\n\n${data.description || ''}`,
       ], { type: 'text/markdown' })

--- a/shared/models/ProjectHandler.ts
+++ b/shared/models/ProjectHandler.ts
@@ -17,7 +17,9 @@ export class ProjectHandler {
   async createProject(project: Project): Promise<void> {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) return
-    await supabase.from('projects').insert({
+    const { data } = await supabase
+      .from('projects')
+      .insert({
       user_id: user.id,
       goal_id: project.goal.id,
       name: project.name,
@@ -30,7 +32,17 @@ export class ProjectHandler {
       period_to: project.period[1].toISOString().slice(0,10),
       contribution_pct: project.contributionPct,
       status: project.status,
-    })
+      })
+      .select()
+      .single()
+
+    if (data) {
+      const path = `${user.id}/${data.goal_id}/${data.id}/${data.name}.md`
+      const blob = new Blob([
+        `# ${data.name}\n\n${data.description || ''}`,
+      ], { type: 'text/markdown' })
+      await supabase.storage.from('documents').upload(path, blob, { upsert: true })
+    }
   }
 
   async deleteProject(id: string): Promise<void> {

--- a/shared/models/TopicHandler.ts
+++ b/shared/models/TopicHandler.ts
@@ -30,7 +30,8 @@ export class TopicHandler {
       .single()
 
     if (data) {
-      const path = `${user.id}/${topic.project.goal.id}/${topic.project.id}/${data.id}/${data.name}.md`
+      const safeName = encodeURIComponent(data.name)
+      const path = `${user.id}/${topic.project.goal.id}/${topic.project.id}/${data.id}/${safeName}.md`
       const blob = new Blob([
         `# ${data.name}\n\n${data.short_description || ''}`,
       ], { type: 'text/markdown' })
@@ -81,7 +82,8 @@ export class TopicHandler {
       .eq('id', topicId)
       .single()
     if (!data) return ''
-    const path = `${user.id}/${data.projects.goal_id}/${data.project_id}/${topicId}/${data.name}.md`
+    const safeName = encodeURIComponent(data.name)
+    const path = `${user.id}/${data.projects.goal_id}/${data.project_id}/${topicId}/${safeName}.md`
     const { data: file } = await supabase.storage.from('documents').download(path)
     if (!file) return ''
     return await file.text()


### PR DESCRIPTION
## Summary
- manage documents in Supabase storage
- create markdown description files when goals, projects or topics are created
- document bucket structure in README

## Testing
- `npm run lint` *(fails: Mixed spaces and tabs and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685052d49030832b94635afdd32d9d94