### PR TITLE
Implement supabase upload for documents

### DIFF
--- a/shared/models/DocumentHandler.ts
+++ b/shared/models/DocumentHandler.ts
@@ -1,3 +1,4 @@
+import supabase from '../db/supabase'
 import { Document } from './Document'
 
 export class DocumentHandler {
@@ -24,7 +25,16 @@ export class DocumentHandler {
     return _document
   }
 
-  async uploadDocument(_documentId: string, _file: File): Promise<void> {}
+  async uploadDocument(documentId: string, file: File): Promise<void> {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) throw new Error('User not authenticated')
+
+    const path = `${user.id}/${documentId}/${file.name}`
+    const { error } = await supabase.storage.from('documents').upload(path, file)
+    if (error) throw error
+  }
 
   async getDocument(_id: string): Promise<{ name: string; type: string; content: string | null }> {
     return { name: '', type: '', content: null }


### PR DESCRIPTION
## Summary
- upload document files to the `documents` bucket when submitting in the UI

## Testing
- `npm run lint` *(fails: 354 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685085435258832bbccbc35b5141fde7