### PR TITLE
Add markdown docs for goals, projects and topics

### DIFF
--- a/app/src/components/tabs/project/OverviewTab.tsx
+++ b/app/src/components/tabs/project/OverviewTab.tsx
@@ -15,6 +15,7 @@ interface OverviewTabProps {
 
 const OverviewTab: React.FC<OverviewTabProps> = ({ project }) => {
   const [counts, setCounts] = useState({ tasks: 0, topics: 0, documents: 0 })
+  const [markdown, setMarkdown] = useState('')
   const taskHandler = React.useMemo(() => TaskHandler.getInstance(), [])
   const topicHandler = React.useMemo(() => TopicHandler.getInstance(), [])
   const documentHandler = React.useMemo(() => DocumentHandler.getInstance(), [])
@@ -29,6 +30,10 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ project }) => {
         setCounts({ tasks: t.length, topics: tp.length, documents: d.length })
       )
       .catch(() => setCounts({ tasks: 0, topics: 0, documents: 0 }))
+    documentHandler
+      .getMarkdownForProject(project.goal.id, project.id)
+      .then(setMarkdown)
+      .catch(() => setMarkdown(''))
   }, [project.goal.id, project.id, taskHandler, topicHandler, documentHandler])
 
   const progress = Math.round(project.progressPercentage)
@@ -41,7 +46,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ project }) => {
     if ((window as any).MathJax?.typeset) {
       ;(window as any).MathJax.typeset()
     }
-  }, [project.description])
+  }, [markdown])
 
   return (
     <div className="space-y-4">
@@ -83,7 +88,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ project }) => {
           td: ({ node, ...props }) => <td className="border px-2 py-1" {...props} />,
         }}
       >
-        {project.description}
+        {markdown || project.description}
       </ReactMarkdown>
     </div>
   )

--- a/app/src/components/tabs/project/TopicTab.tsx
+++ b/app/src/components/tabs/project/TopicTab.tsx
@@ -27,7 +27,11 @@ const TopicTab: React.FC<TopicTabProps> = ({ project }) => {
 
   const openTopic = async (topic: Topic) => {
     setActiveTopic(topic)
-    const md = await topicHandler.getMarkdownForTopic(topic.id)
+    const md = await topicHandler.getMarkdownForTopic(
+      topic.project.goal.id,
+      topic.project.id,
+      topic.id
+    )
     setMarkdown(md)
   }
 

--- a/shared/models/DocumentHandler.ts
+++ b/shared/models/DocumentHandler.ts
@@ -78,4 +78,46 @@ export class DocumentHandler {
   async deleteDocument(fullPath: string): Promise<void> {
     await supabase.storage.from('documents').remove([fullPath])
   }
+
+  async uploadMarkdown(relativePath: string, content: string): Promise<void> {
+    const file = new File(
+      [content],
+      relativePath.split('/').pop() || 'note.md',
+      { type: 'text/markdown' }
+    )
+    await this.uploadDocument(relativePath, file)
+  }
+
+  async getMarkdown(relativePath: string): Promise<string> {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return ''
+    const { data, error } = await supabase.storage
+      .from('documents')
+      .download(`${user.id}/${relativePath}`)
+    if (error || !data) return ''
+    return data.text()
+  }
+
+  async getMarkdownForGoal(goalId: string): Promise<string> {
+    return this.getMarkdown(`${goalId}/goal.${goalId}.md`)
+  }
+
+  async getMarkdownForProject(
+    goalId: string,
+    projectId: string
+  ): Promise<string> {
+    return this.getMarkdown(`${goalId}/${projectId}/project.${projectId}.md`)
+  }
+
+  async getMarkdownForTopic(
+    goalId: string,
+    projectId: string,
+    topicId: string
+  ): Promise<string> {
+    return this.getMarkdown(
+      `${goalId}/${projectId}/${topicId}/topic.${topicId}.md`
+    )
+  }
 }

--- a/shared/models/DocumentHandler.ts
+++ b/shared/models/DocumentHandler.ts
@@ -101,14 +101,14 @@ export class DocumentHandler {
   }
 
   async getMarkdownForGoal(goalId: string): Promise<string> {
-    return this.getMarkdown(`${goalId}/goal.${goalId}.md`)
+    return this.getMarkdown(`${goalId}/${goalId}.md`)
   }
 
   async getMarkdownForProject(
     goalId: string,
     projectId: string
   ): Promise<string> {
-    return this.getMarkdown(`${goalId}/${projectId}/project.${projectId}.md`)
+    return this.getMarkdown(`${goalId}/${projectId}/${projectId}.md`)
   }
 
   async getMarkdownForTopic(
@@ -117,7 +117,7 @@ export class DocumentHandler {
     topicId: string
   ): Promise<string> {
     return this.getMarkdown(
-      `${goalId}/${projectId}/${topicId}/topic.${topicId}.md`
+      `${goalId}/${projectId}/${topicId}/${topicId}.md`
     )
   }
 }

--- a/shared/models/GoalHandler.ts
+++ b/shared/models/GoalHandler.ts
@@ -1,5 +1,7 @@
 import supabase from '../db/supabase'
 import { Goal } from './Goal'
+import { DocumentHandler } from './DocumentHandler'
+import { MOCK_MARKDOWN } from '../utils/mockMarkdown'
 
 export class GoalHandler {
   private static instance: GoalHandler | null = null
@@ -30,6 +32,10 @@ export class GoalHandler {
       status: goal.status,
       area_of_life: goal.aol,
     })
+    await DocumentHandler.getInstance().uploadMarkdown(
+      `${goal.id}/goal.${goal.id}.md`,
+      MOCK_MARKDOWN
+    )
   }
 
   async deleteGoal(id: string): Promise<void> {

--- a/shared/models/GoalHandler.ts
+++ b/shared/models/GoalHandler.ts
@@ -20,7 +20,9 @@ export class GoalHandler {
   async createGoal(goal: Goal): Promise<void> {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) return
-    await supabase.from('goals').insert({
+    const { data: inserted, error } = await supabase
+      .from('goals')
+      .insert({
       user_id: user.id,
       name: goal.name,
       description: goal.description,
@@ -31,9 +33,13 @@ export class GoalHandler {
       period_to: goal.period[1].toISOString().slice(0,10),
       status: goal.status,
       area_of_life: goal.aol,
-    })
+      })
+      .select()
+      .single()
+    if (error || !inserted) return
+    goal.id = inserted.id
     await DocumentHandler.getInstance().uploadMarkdown(
-      `${goal.id}/goal.${goal.id}.md`,
+      `${goal.id}/${goal.id}.md`,
       MOCK_MARKDOWN
     )
   }

--- a/shared/models/ProjectHandler.ts
+++ b/shared/models/ProjectHandler.ts
@@ -19,7 +19,9 @@ export class ProjectHandler {
   async createProject(project: Project): Promise<void> {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) return
-    await supabase.from('projects').insert({
+    const { data: inserted, error } = await supabase
+      .from('projects')
+      .insert({
       user_id: user.id,
       goal_id: project.goal.id,
       name: project.name,
@@ -32,9 +34,13 @@ export class ProjectHandler {
       period_to: project.period[1].toISOString().slice(0,10),
       contribution_pct: project.contributionPct,
       status: project.status,
-    })
+      })
+      .select()
+      .single()
+    if (error || !inserted) return
+    project.id = inserted.id
     await DocumentHandler.getInstance().uploadMarkdown(
-      `${project.goal.id}/${project.id}/project.${project.id}.md`,
+      `${project.goal.id}/${project.id}/${project.id}.md`,
       MOCK_MARKDOWN
     )
   }

--- a/shared/models/ProjectHandler.ts
+++ b/shared/models/ProjectHandler.ts
@@ -1,6 +1,8 @@
 import supabase from '../db/supabase'
 import { Project } from './Project'
 import { Goal } from './Goal'
+import { DocumentHandler } from './DocumentHandler'
+import { MOCK_MARKDOWN } from '../utils/mockMarkdown'
 
 export class ProjectHandler {
   private static instance: ProjectHandler | null = null
@@ -31,6 +33,10 @@ export class ProjectHandler {
       contribution_pct: project.contributionPct,
       status: project.status,
     })
+    await DocumentHandler.getInstance().uploadMarkdown(
+      `${project.goal.id}/${project.id}/project.${project.id}.md`,
+      MOCK_MARKDOWN
+    )
   }
 
   async deleteProject(id: string): Promise<void> {

--- a/shared/models/TopicHandler.ts
+++ b/shared/models/TopicHandler.ts
@@ -56,7 +56,7 @@ export class TopicHandler {
     topicId: string
   ): Promise<string> {
     return DocumentHandler.getInstance().getMarkdown(
-      `${goalId}/${projectId}/${topicId}/topic.${topicId}.md`
+      `${goalId}/${projectId}/${topicId}/${topicId}.md`
     )
   }
 }

--- a/shared/models/TopicHandler.ts
+++ b/shared/models/TopicHandler.ts
@@ -2,6 +2,7 @@ import supabase from '../db/supabase'
 import { Topic } from './Topic'
 import { Project } from './Project'
 import { Goal } from './Goal'
+import { DocumentHandler } from './DocumentHandler'
 
 export class TopicHandler {
   private static instance: TopicHandler | null = null
@@ -49,7 +50,13 @@ export class TopicHandler {
     ))
   }
 
-  async getMarkdownForTopic(_topicId: string): Promise<string> {
-    return ''
+  async getMarkdownForTopic(
+    goalId: string,
+    projectId: string,
+    topicId: string
+  ): Promise<string> {
+    return DocumentHandler.getInstance().getMarkdown(
+      `${goalId}/${projectId}/${topicId}/topic.${topicId}.md`
+    )
   }
 }

--- a/shared/utils/mockMarkdown.ts
+++ b/shared/utils/mockMarkdown.ts
@@ -1,0 +1,28 @@
+export const MOCK_MARKDOWN = `# Overview
+
+This document demonstrates **Markdown** features.
+
+## List
+- Item 1
+- Item 2
+
+Inline code: \`console.log('hello')\`
+
+\`\`\`ts
+function example() {
+  return 'code block';
+}
+\`\`\`
+
+Inline LaTeX: $e^{i\\pi}+1=0$
+
+$$
+\\int_a^b f(x)\\,dx = F(b)-F(a)
+$$
+
+| Column | Value |
+| ------ | ----- |
+| A | 1 |
+| B | 2 |
+`;
+


### PR DESCRIPTION
## Summary
- add a mock markdown template
- extend DocumentHandler with helpers for markdown
- upload markdown when creating goals and projects
- fetch topic markdown with project/goal context
- display project markdown in OverviewTab

## Testing
- `npm run lint` *(fails: no-mixed-spaces-and-tabs and no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851c3a7bc70832bb0f912f10010eaa0