### PR TITLE
Revamp goal overview and document listing

### DIFF
--- a/app/src/components/tabs/goal/DocumentTab.tsx
+++ b/app/src/components/tabs/goal/DocumentTab.tsx
@@ -23,7 +23,9 @@ const DocumentTab: React.FC<DocumentTabProps> = ({ goal, isEditing }) => {
   const loadDocuments = React.useCallback(() => {
     handler
       .getDocumentsForGoal(goal.id)
-      .then(setDocuments)
+      .then(d =>
+        setDocuments(d.filter(doc => doc.name !== `${goal.id}.md`))
+      )
       .catch(console.error)
   }, [goal.id, handler])
 


### PR DESCRIPTION
## Summary
- filter out goal description markdown from document tab
- redesign goal overview tab like project overview

## Testing
- `npm run lint` *(fails: 352 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68528396657c832b8f1206a187dd4580