### PR TITLE
Remove shortDescription from Project

### DIFF
--- a/app/src/modals/AddProjectModal.tsx
+++ b/app/src/modals/AddProjectModal.tsx
@@ -20,7 +20,6 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
       .catch(() => setGoals([]));
   }, []);
   const [name, setName] = useState('');
-  const [shortDescription, setShortDescription] = useState('');
   const [description, setDescription] = useState('');
   const [start, setStart] = useState(0);
   const [current, setCurrent] = useState(0);
@@ -48,7 +47,6 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
     const project = new Project(
       Date.now().toString(),
       name,
-      shortDescription,
       description,
       start,
       current,
@@ -62,7 +60,6 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
     onClose();
     // reset fields
     setName('');
-    setShortDescription('');
     setDescription('');
     setStart(0);
     setCurrent(0);
@@ -86,15 +83,6 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="w-full p-2 border border-gray-300 rounded"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Short Description</label>
-        <input
-          type="text"
-          value={shortDescription}
-          onChange={(e) => setShortDescription(e.target.value)}
           className="w-full p-2 border border-gray-300 rounded"
         />
       </div>

--- a/app/src/pages/ProjectPage.tsx
+++ b/app/src/pages/ProjectPage.tsx
@@ -27,7 +27,7 @@ export default function ProjectPage() {
   };
 
   const filtered = projects.filter((p) =>
-    `${p.name} ${p.shortDescription} ${p.description}`
+    `${p.name} ${p.description}`
       .toLowerCase()
       .includes(search.toLowerCase()),
   );
@@ -76,7 +76,7 @@ export default function ProjectPage() {
                   className={`${containerStyle[project.status]} p-4 rounded-lg shadow hover:shadow-md transition-shadow cursor-pointer border border-gray-200 flex flex-col h-full`}
                 >
                   <h2 className="text-lg font-semibold">{project.name}</h2>
-                  <p className="text-sm text-gray-600 line-clamp-3">{project.shortDescription}</p>
+                  <p className="text-sm text-gray-600 line-clamp-3">{project.description}</p>
                   <span
                     className={`${statusLabelStyle[project.status]} flex-shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full mt-auto self-start`}
                   >

--- a/backend/setup/projects.sql
+++ b/backend/setup/projects.sql
@@ -3,7 +3,6 @@ create table public.projects (
   user_id uuid references auth.users(id) not null,
   goal_id uuid references public.goals(id) on delete cascade,
   name text not null,
-  short_description text,
   description text,
   start numeric,
   current numeric,

--- a/shared/models/Project.ts
+++ b/shared/models/Project.ts
@@ -5,7 +5,6 @@ import { APP_CONFIG } from "../utils/appConfig";
 export class Project {
   id: string;
   name: string;
-  shortDescription: string;
   description: string;
   start: number;
   current: number;
@@ -31,7 +30,6 @@ export class Project {
     constructor(
         id: string,
         name: string,
-        shortDescription: string,
         description: string,
         start: number,
         current: number,
@@ -42,7 +40,6 @@ export class Project {
     ) {
         this.id = id;
         this.name = name;
-        this.shortDescription = shortDescription;
         this.description = description;
         this.start = start;
         this.current = current;

--- a/shared/models/ProjectHandler.test.ts
+++ b/shared/models/ProjectHandler.test.ts
@@ -18,7 +18,6 @@ function createProject(id: number, goal: Goal): Project {
     id,
     `p${id}`,
     '',
-    '',
     0,
     0,
     1,

--- a/shared/models/ProjectHandler.ts
+++ b/shared/models/ProjectHandler.ts
@@ -26,7 +26,6 @@ export class ProjectHandler {
       user_id: user.id,
       goal_id: project.goal.id,
       name: project.name,
-      short_description: project.shortDescription,
       description: project.description,
       start: project.start,
       current: project.current,
@@ -67,7 +66,6 @@ export class ProjectHandler {
     return data.map(p => new Project(
       p.id,
       p.name,
-      p.short_description ?? '',
       p.description ?? '',
       p.start,
       p.current,
@@ -96,7 +94,6 @@ export class ProjectHandler {
     return data.map(p => new Project(
       p.id,
       p.name,
-      p.short_description ?? '',
       p.description ?? '',
       p.start,
       p.current,

--- a/shared/models/TaskHandler.ts
+++ b/shared/models/TaskHandler.ts
@@ -18,7 +18,7 @@ export class TaskHandler {
   async getTasksForProject(projectId: string): Promise<Task[]> {
     const { data, error } = await supabase
       .from('tasks')
-      .select('*, projects!inner(goal_id, name, short_description, description, start, current, objective, period_from, period_to, contribution_pct, goals:goals(id, name, description, start, current, objective, period_from, period_to, area_of_life))')
+      .select('*, projects!inner(goal_id, name, description, start, current, objective, period_from, period_to, contribution_pct, goals:goals(id, name, description, start, current, objective, period_from, period_to, area_of_life))')
       .eq('project_id', projectId)
     if (error || !data) return []
     return data.map(t => {
@@ -27,7 +27,6 @@ export class TaskHandler {
       const project = new Project(
         p.goal_id, // id will be overwritten below after supabase fix
         p.name,
-        p.short_description ?? '',
         p.description ?? '',
         p.start,
         p.current,

--- a/shared/models/TopicHandler.ts
+++ b/shared/models/TopicHandler.ts
@@ -29,7 +29,6 @@ export class TopicHandler {
       new Project(
         t.projects.id,
         t.projects.name,
-        t.projects.short_description ?? '',
         t.projects.description ?? '',
         t.projects.start,
         t.projects.current,


### PR DESCRIPTION
## Summary
- drop `shortDescription` field from Project domain model
- update handlers and tests to match constructor change
- simplify AddProjectModal form
- search filter and overview show project description instead

## Testing
- `npm run lint` *(fails: React must be in scope, many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68528db28084832b84b75cd197c0e52d