### PR TITLE
Add chat speed dial

### DIFF
--- a/app/src/components/ui/speed-dial.tsx
+++ b/app/src/components/ui/speed-dial.tsx
@@ -8,7 +8,10 @@ import {
   Edit,
   BotMessageSquare,
 } from 'lucide-react'
-import axios from 'axios'
+
+interface SpeedDialProps {
+  onAskQuestion?: () => void
+}
 
 interface Action {
   label: string;
@@ -16,7 +19,7 @@ interface Action {
   onClick: () => void;
 }
 
-export const SpeedDial = () => {
+export const SpeedDial: React.FC<SpeedDialProps> = ({ onAskQuestion }) => {
   const [open, setOpen] = useState(false);
 
   const actions: Action[] = [
@@ -24,26 +27,8 @@ export const SpeedDial = () => {
     {
       label: 'Ask a Question',
       icon: <BotMessageSquare className="w-5 h-5" />,
-      onClick: async () => {
-        const url = import.meta.env.VITE_RAG_AGENT_WEBHOOK
-        if (!url) return
-        try {
-          const response = await axios.post(url, {
-              session_id: '00888e6a2d014d5cb70d43b009d0ba80',
-              chat_input: 'What documents are in my database?',
-              goal_id: '221ff76a-16ff-4ed8-aaeb-4d6557f8bc90',
-          },
-            {
-              headers: {
-                'Content-Type': 'application/json',
-              },
-            },
-          )
-          console.log('Response from RAG agent:', response.data)
-        } catch (err) {
-          /* eslint-disable no-console */
-          console.error(err)
-        }
+      onClick: () => {
+        onAskQuestion?.()
       },
     },
     //{ label: "Download", icon: <Download className="w-5 h-5" />, onClick: () => {} },

--- a/app/src/components/ui/typing-indicator.tsx
+++ b/app/src/components/ui/typing-indicator.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const TypingIndicator: React.FC = () => (
+  <div className="flex space-x-1">
+    <span className="w-2 h-2 bg-gray-400 rounded-full animate-dot-bounce" />
+    <span className="w-2 h-2 bg-gray-400 rounded-full animate-dot-bounce [animation-delay:.2s]" />
+    <span className="w-2 h-2 bg-gray-400 rounded-full animate-dot-bounce [animation-delay:.4s]" />
+  </div>
+)
+
+export default TypingIndicator

--- a/app/src/components/views/ChatView.tsx
+++ b/app/src/components/views/ChatView.tsx
@@ -106,7 +106,7 @@ const ChatView: React.FC<ChatViewProps> = ({ chat, goalId, projectId }) => {
             ) : (
               <CleanChatBubble>
                 {m.isError ? (
-                  <div className="flex items-center gap-2 rounded bg-red-50 border border-red-200 text-red-800 p-2">
+                  <div className="flex items-center gap-2 rounded-3xl bg-red-50 border border-red-200 text-red-800 p-2">
                     <XCircle className="w-4 h-4" />
                     <span>{m.text}</span>
                   </div>

--- a/app/src/components/views/ChatView.tsx
+++ b/app/src/components/views/ChatView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import axios from 'axios'
+import { XCircle } from 'lucide-react'
 import { Chat, ChatMessage } from '@/models/Chat'
 import ChatBubble from '@/components/ui/chat-bubble'
 import CleanChatBubble from '@/components/ui/clean-chat-bubble'
@@ -57,7 +58,11 @@ const ChatView: React.FC<ChatViewProps> = ({ chat, goalId, projectId }) => {
       console.error(err)
       setMessages(prev => [
         ...prev,
-        { sender: 'assistant', text: 'Failed to get response.' },
+        {
+          sender: 'assistant',
+          text: 'Failed to get a response',
+          isError: true,
+        },
       ])
     } finally {
       setIsLoading(false)
@@ -81,35 +86,48 @@ const ChatView: React.FC<ChatViewProps> = ({ chat, goalId, projectId }) => {
           >
             {m.sender === 'user' ? (
               <ChatBubble>
-                <ReactMarkdown remarkPlugins={[remarkGfm]} components={{
-                  table: ({ node, ...props }) => (
-                    <table className="min-w-full border border-gray-300 text-sm" {...props} />
-                  ),
-                  th: ({ node, ...props }) => (
-                    <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
-                  ),
-                  td: ({ node, ...props }) => (
-                    <td className="border px-2 py-1" {...props} />
-                  ),
-                }}>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    table: (props) => (
+                      <table className="min-w-full border border-gray-300 text-sm" {...props} />
+                    ),
+                    th: (props) => (
+                      <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
+                    ),
+                    td: (props) => (
+                      <td className="border px-2 py-1" {...props} />
+                    ),
+                  }}
+                >
                   {m.text}
                 </ReactMarkdown>
               </ChatBubble>
             ) : (
               <CleanChatBubble>
-                <ReactMarkdown remarkPlugins={[remarkGfm]} components={{
-                  table: ({ node, ...props }) => (
-                    <table className="min-w-full border border-gray-300 text-sm" {...props} />
-                  ),
-                  th: ({ node, ...props }) => (
-                    <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
-                  ),
-                  td: ({ node, ...props }) => (
-                    <td className="border px-2 py-1" {...props} />
-                  ),
-                }}>
-                  {m.text}
-                </ReactMarkdown>
+                {m.isError ? (
+                  <div className="flex items-center gap-2 rounded bg-red-50 border border-red-200 text-red-800 p-2">
+                    <XCircle className="w-4 h-4" />
+                    <span>{m.text}</span>
+                  </div>
+                ) : (
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                      table: (props) => (
+                        <table className="min-w-full border border-gray-300 text-sm" {...props} />
+                      ),
+                      th: (props) => (
+                        <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
+                      ),
+                      td: (props) => (
+                        <td className="border px-2 py-1" {...props} />
+                      ),
+                    }}
+                  >
+                    {m.text}
+                  </ReactMarkdown>
+                )}
               </CleanChatBubble>
             )}
           </div>

--- a/app/src/components/views/GoalDetailView.tsx
+++ b/app/src/components/views/GoalDetailView.tsx
@@ -10,6 +10,8 @@ import {
   LucideProps,
 } from 'lucide-react';
 import Modal from '@/components/ui/modal';
+import { SpeedDial } from '@/components/ui/speed-dial';
+import ChatView from '@/components/views/ChatView';
 import OverviewTab from '../tabs/goal/OverviewTab';
 import ProjectTab from '../tabs/goal/ProjectTab';
 import TaskTab from '../tabs/goal/TaskTab';
@@ -32,6 +34,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
   const [editedGoal, setEditedGoal] = useState<Goal>(goal);
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showChat, setShowChat] = useState(false);
 
   useEffect(() => {
     setEditedGoal(goal);
@@ -147,6 +150,8 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
 
       <div className="mt-4">{renderTabContent()}</div>
 
+      <SpeedDial onAskQuestion={() => setShowChat(true)} />
+
       <Modal isOpen={showDeleteConfirm} onClose={() => setShowDeleteConfirm(false)} title="Confirm delete goal">
         <p className="mb-4">
           Are you sure you want to permanently delete the goal <strong>{goal.name}</strong>? This action cannot be undone.
@@ -165,6 +170,10 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
             Confirm Delete
           </button>
         </div>
+      </Modal>
+
+      <Modal isOpen={showChat} onClose={() => setShowChat(false)} title="Ask a question">
+        <ChatView goalId={goal.id} />
       </Modal>
     </div>
   );

--- a/app/src/components/views/ProjectDetailView.tsx
+++ b/app/src/components/views/ProjectDetailView.tsx
@@ -15,6 +15,8 @@ import TaskTab from '../tabs/project/TaskTab'
 import TopicTab from '../tabs/project/TopicTab'
 import DocumentTab from '../tabs/project/DocumentTab'
 import Modal from '@/components/ui/modal'
+import { SpeedDial } from '@/components/ui/speed-dial'
+import ChatView from '@/components/views/ChatView'
 
 interface ProjectDetailViewProps {
   project: Project
@@ -30,6 +32,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
   const [activeTab, setActiveTab] = useState('overview')
   const [currentProject, setCurrentProject] = useState<Project>(project)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [showChat, setShowChat] = useState(false)
 
   const handleDelete = async () => {
     try {
@@ -109,6 +112,8 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
         </nav>
       </div>
       <div className="mt-4">{renderTabContent()}</div>
+
+      <SpeedDial onAskQuestion={() => setShowChat(true)} />
       <Modal
         isOpen={showDeleteConfirm}
         onClose={() => setShowDeleteConfirm(false)}
@@ -132,6 +137,10 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
             Confirm Delete
           </button>
         </div>
+      </Modal>
+
+      <Modal isOpen={showChat} onClose={() => setShowChat(false)} title="Ask a question">
+        <ChatView projectId={project.id} />
       </Modal>
     </div>
   )

--- a/app/src/models/Chat.ts
+++ b/app/src/models/Chat.ts
@@ -3,6 +3,7 @@ import { Topic } from './Topic'
 export interface ChatMessage {
   sender: 'user' | 'assistant'
   text: string
+  isError?: boolean
 }
 
 export class Chat {

--- a/app/tailwind.config.ts
+++ b/app/tailwind.config.ts
@@ -75,28 +75,33 @@ export default {
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
   		},
-  		keyframes: {
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		}
+                keyframes: {
+                        'accordion-down': {
+                                from: {
+                                        height: '0'
+                                },
+                                to: {
+                                        height: 'var(--radix-accordion-content-height)'
+                                }
+                        },
+                        'accordion-up': {
+                                from: {
+                                        height: 'var(--radix-accordion-content-height)'
+                                },
+                                to: {
+                                        height: '0'
+                                }
+                        },
+                        'dot-bounce': {
+                                '0%,80%,100%': { transform: 'scale(0)' },
+                                '40%': { transform: 'scale(1)' }
+                        }
+                },
+                animation: {
+                        'accordion-down': 'accordion-down 0.2s ease-out',
+                        'accordion-up': 'accordion-up 0.2s ease-out',
+                        'dot-bounce': 'dot-bounce 1.4s infinite both'
+                }
   	}
   },
   plugins: [


### PR DESCRIPTION
## Summary
- add SpeedDial prop to trigger ask-question callback
- call RAG agent from ChatView via speed dial
- show SpeedDial and chat modal on goal and project detail views

## Testing
- `npm run lint` *(fails: 346 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685663d47e20832b96b2acfa9a3b5096