### PR TITLE
Fix LaTeX display in markdown views

### DIFF
--- a/app/src/components/tabs/goal/OverviewTab.tsx
+++ b/app/src/components/tabs/goal/OverviewTab.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { applyMathJaxDelimiters } from '@/utils/markdown';
 import { Goal } from '@/models/Goal';
 import { ProjectHandler } from '@/models/ProjectHandler';
 import { DocumentHandler } from '@/models/DocumentHandler';
@@ -81,7 +82,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ goal }) => {
           td: ({ node, ...props }) => <td className="border px-2 py-1" {...props} />,
         }}
       >
-        {markdown || goal.description}
+        {applyMathJaxDelimiters(markdown || goal.description)}
       </ReactMarkdown>
     </div>
   );

--- a/app/src/components/tabs/project/OverviewTab.tsx
+++ b/app/src/components/tabs/project/OverviewTab.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { applyMathJaxDelimiters } from '@/utils/markdown'
 import { Project } from '@/models/Project'
 import { TaskHandler } from '@/models/TaskHandler'
 import { TopicHandler } from '@/models/TopicHandler'
@@ -94,7 +95,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ project }) => {
           td: ({ node, ...props }) => <td className="border px-2 py-1" {...props} />,
         }}
       >
-        {markdown || project.description}
+        {applyMathJaxDelimiters(markdown || project.description)}
       </ReactMarkdown>
     </div>
   )

--- a/app/src/components/views/ChatView.tsx
+++ b/app/src/components/views/ChatView.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { applyMathJaxDelimiters } from '@/utils/markdown'
 import axios from 'axios'
 import { XCircle } from 'lucide-react'
 import { Chat, ChatMessage } from '@/models/Chat'
@@ -100,7 +101,7 @@ const ChatView: React.FC<ChatViewProps> = ({ chat, goalId, projectId }) => {
                     ),
                   }}
                 >
-                  {m.text}
+                  {applyMathJaxDelimiters(m.text)}
                 </ReactMarkdown>
               </ChatBubble>
             ) : (
@@ -125,7 +126,7 @@ const ChatView: React.FC<ChatViewProps> = ({ chat, goalId, projectId }) => {
                       ),
                     }}
                   >
-                    {m.text}
+                    {applyMathJaxDelimiters(m.text)}
                   </ReactMarkdown>
                 )}
               </CleanChatBubble>

--- a/app/src/components/views/TopicDetailView.tsx
+++ b/app/src/components/views/TopicDetailView.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { applyMathJaxDelimiters } from '@/utils/markdown'
 import { ArrowLeft, ChevronDown, ChevronUp } from 'lucide-react'
 import { Topic } from '@/models/Topic'
 import { Chat } from '@/models/Chat'
@@ -50,7 +51,7 @@ const TopicDetailView: React.FC<TopicDetailViewProps> = ({
           td: ({ node, ...props }) => <td className="border px-2 py-1" {...props} />,
         }}
       >
-        {markdown}
+        {applyMathJaxDelimiters(markdown)}
       </ReactMarkdown>
       {chats.length > 0 && (
         <div>

--- a/app/src/utils/markdown.ts
+++ b/app/src/utils/markdown.ts
@@ -1,0 +1,13 @@
+/**
+ * Converts LaTeX math delimiters in Markdown to formats
+ * recognized by MathJax. Inline `$...$` expressions become
+ * `\(...\)` and block `$$...$$` become `\[...\]`.
+ *
+ * @param text - Markdown string potentially containing LaTeX.
+ * @returns Updated Markdown string ready for MathJax typesetting.
+ */
+export function applyMathJaxDelimiters(text: string): string {
+  return text
+    .replace(/\$\$([\s\S]+?)\$\$/g, '\\[$1\\]')
+    .replace(/\$(?!\$)([^$]+)\$/g, '\\($1\\)');
+}


### PR DESCRIPTION
## Summary
- preprocess markdown to use MathJax delimiters
- render processed markdown in ChatView and detail/overview views

## Testing
- `npm run lint` *(fails: Expected usable value but received an empty preset)*

------
https://chatgpt.com/codex/tasks/task_e_685675a05b38832b898e1f2d37fd6602