### PR TITLE
Add chat to goal tasks and send ids

### DIFF
--- a/app/src/components/tabs/goal/TaskTab.tsx
+++ b/app/src/components/tabs/goal/TaskTab.tsx
@@ -3,6 +3,11 @@ import { Goal } from '@/models/Goal';
 import { AutomatedTask, AutomationState } from '@/models/Task';
 import { StatusIndicator } from '@/components/ui/status-indicator';
 import { ChevronDown, ChevronUp } from 'lucide-react';
+import Modal from '@/components/ui/modal';
+import ChatView from '@/components/views/ChatView';
+import { Chat } from '@/models/Chat';
+import { Topic } from '@/models/Topic';
+import { Project } from '@/models/Project';
 
 interface TaskTabProps {
   goal: Goal;
@@ -17,6 +22,7 @@ const automationStyle: Record<AutomationState, string> = {
 
 const TaskTab: React.FC<TaskTabProps> = ({ goal }) => {
   const [tasks, setTasks] = useState<AutomatedTask[]>([]);
+  const [activeChat, setActiveChat] = useState<Chat | null>(null);
   const [showTimeline, setShowTimeline] = useState(false);
 
   const sortTasks = (list: AutomatedTask[]) =>
@@ -30,6 +36,23 @@ const TaskTab: React.FC<TaskTabProps> = ({ goal }) => {
     setTasks(sortTasks(goal.tasks ?? []));
   }, [goal]);
 
+  const openTask = (task: AutomatedTask) => {
+    const dummyProject = new Project(
+      '',
+      goal.name,
+      '',
+      goal.start,
+      goal.current,
+      goal.objective,
+      goal.period,
+      goal,
+      100,
+    );
+    const dummyTopic = new Topic('0', 'Task Chat', '', dummyProject);
+    const chat = new Chat(task.id, task.name, task.description, [], dummyTopic);
+    setActiveChat(chat);
+  };
+
 
   return (
     <div className="space-y-4">
@@ -41,7 +64,8 @@ const TaskTab: React.FC<TaskTabProps> = ({ goal }) => {
             .map(task => (
               <li
                 key={task.id}
-                className={`${automationStyle[task.status]} p-3 rounded-md flex justify-between items-center gap-2`}
+                onClick={() => openTask(task)}
+                className={`${automationStyle[task.status]} p-3 rounded-md flex justify-between items-center gap-2 cursor-pointer`}
               >
                 <div className="flex-1">
                   <p className="font-medium text-sm text-gray-800">{task.name}</p>
@@ -80,6 +104,12 @@ const TaskTab: React.FC<TaskTabProps> = ({ goal }) => {
             </ul>
           )}
         </div>
+      )}
+
+      {activeChat && (
+        <Modal isOpen={!!activeChat} onClose={() => setActiveChat(null)} title={activeChat.title}>
+          <ChatView chat={activeChat} goalId={goal.id} />
+        </Modal>
       )}
 
     </div>

--- a/app/src/components/tabs/project/TaskTab.tsx
+++ b/app/src/components/tabs/project/TaskTab.tsx
@@ -154,7 +154,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ project }) => {
 
       {activeChat && (
         <Modal isOpen={!!activeChat} onClose={() => setActiveChat(null)} title={activeChat.title}>
-          <ChatView chat={activeChat} />
+          <ChatView chat={activeChat} projectId={project.id} />
         </Modal>
       )}
     </div>

--- a/app/src/components/views/ChatView.tsx
+++ b/app/src/components/views/ChatView.tsx
@@ -19,7 +19,7 @@ const ChatView: React.FC<ChatViewProps> = ({ chat, goalId, projectId }) => {
   const [messages, setMessages] = useState<ChatMessage[]>(chat?.messages ?? [])
   const [isLoading, setIsLoading] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
-  const sessionIdRef = useRef<string>(crypto.randomUUID())
+  const sessionIdRef = useRef<string>(goalId ?? projectId ?? crypto.randomUUID())
 
   const handleSubmit = async (text: string) => {
     if (!text.trim()) return


### PR DESCRIPTION
## Summary
- open task chats for goals like projects
- pass project and goal ids to ChatView
- use goal/project id as chat session id

## Testing
- `npm run lint` *(fails: Mixed spaces and tabs errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856a925c6cc832bac09960dae94304e