### PR TITLE
Add notification badge for attention tasks

### DIFF
--- a/app/src/components/views/GoalDetailView.tsx
+++ b/app/src/components/views/GoalDetailView.tsx
@@ -101,7 +101,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
   const TabButton: React.FC<TabButtonProps> = ({ tabId, label, icon: Icon, badge }) => (
     <button
       onClick={() => setActiveTab(tabId)}
-      className={`flex flex-1 flex-shrink-0 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
+      className={`relative flex flex-1 flex-shrink-0 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
         activeTab === tabId
           ? 'bg-blue-100 text-blue-700'
           : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
@@ -109,7 +109,14 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
     >
       <Icon size={18} className="mr-2" />
       {label}
-      {badge && <Badge variant="destructive" className="ml-1">!</Badge>}
+      {badge && (
+        <Badge
+          variant="destructive"
+          className="pointer-events-none absolute -top-1 -right-1 px-1 py-0 text-xs"
+        >
+          !
+        </Badge>
+      )}
     </button>
   );
 

--- a/app/src/components/views/GoalDetailView.tsx
+++ b/app/src/components/views/GoalDetailView.tsx
@@ -17,6 +17,7 @@ import ProjectTab from '../tabs/goal/ProjectTab';
 import TaskTab from '../tabs/goal/TaskTab';
 import DocumentTab from '../tabs/goal/DocumentTab';
 import { Goal } from '@/models/Goal';
+import { Badge } from '@/components/ui/badge';
 import { GoalHandler } from '@/models/GoalHandler';
 
 interface GoalDetailViewProps {
@@ -35,6 +36,8 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showChat, setShowChat] = useState(false);
+
+  const attentionNeeded = editedGoal.hasAttentionTask();
 
   useEffect(() => {
     setEditedGoal(goal);
@@ -92,9 +95,10 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
     tabId: string;
     label: string;
     icon: React.ComponentType<LucideProps>;
+    badge?: boolean;
   }
 
-  const TabButton: React.FC<TabButtonProps> = ({ tabId, label, icon: Icon }) => (
+  const TabButton: React.FC<TabButtonProps> = ({ tabId, label, icon: Icon, badge }) => (
     <button
       onClick={() => setActiveTab(tabId)}
       className={`flex flex-1 flex-shrink-0 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
@@ -105,6 +109,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
     >
       <Icon size={18} className="mr-2" />
       {label}
+      {badge && <Badge variant="destructive" className="ml-1">!</Badge>}
     </button>
   );
 
@@ -143,7 +148,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
         <nav className="flex space-x-2 overflow-x-auto whitespace-nowrap pb-2" aria-label="Tabs">
           <TabButton tabId="overview" label="Overview" icon={ChartNoAxesCombined} />
           <TabButton tabId="project" label="Projects" icon={ListTodo} />
-          <TabButton tabId="tasks" label="Tasks" icon={Calendar} />
+          <TabButton tabId="tasks" label="Tasks" icon={Calendar} badge={attentionNeeded} />
           <TabButton tabId="documents" label="Documents" icon={FileText} />
         </nav>
       </div>

--- a/app/src/components/views/GoalDetailView.tsx
+++ b/app/src/components/views/GoalDetailView.tsx
@@ -112,7 +112,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
       {badge && (
         <Badge
           variant="destructive"
-          className="pointer-events-none absolute -top-1 -right-1 px-1 py-0 text-xs"
+          className="pointer-events-none absolute -top-1 -right-1 w-4 h-4 text-xs flex items-center justify-center rounded-full p-0"
         >
           !
         </Badge>
@@ -152,7 +152,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
       </div>
 
       <div className="mb-6 border-b border-gray-200">
-        <nav className="flex space-x-2 overflow-x-auto whitespace-nowrap pb-2" aria-label="Tabs">
+        <nav className="flex space-x-2 overflow-visible whitespace-nowrap pb-2" aria-label="Tabs">
           <TabButton tabId="overview" label="Overview" icon={ChartNoAxesCombined} />
           <TabButton tabId="project" label="Projects" icon={ListTodo} />
           <TabButton tabId="tasks" label="Tasks" icon={Calendar} badge={attentionNeeded} />

--- a/app/src/components/views/ProjectDetailView.tsx
+++ b/app/src/components/views/ProjectDetailView.tsx
@@ -17,6 +17,7 @@ import DocumentTab from '../tabs/project/DocumentTab'
 import Modal from '@/components/ui/modal'
 import { SpeedDial } from '@/components/ui/speed-dial'
 import ChatView from '@/components/views/ChatView'
+import { Badge } from '@/components/ui/badge'
 
 interface ProjectDetailViewProps {
   project: Project
@@ -33,6 +34,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
   const [currentProject, setCurrentProject] = useState<Project>(project)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [showChat, setShowChat] = useState(false)
+  const [attentionNeeded, setAttentionNeeded] = useState(false)
 
   const handleDelete = async () => {
     try {
@@ -50,6 +52,9 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
   useEffect(() => {
     setCurrentProject(project)
     setActiveTab('overview')
+    project.hasAttentionTask()
+      .then(setAttentionNeeded)
+      .catch(() => setAttentionNeeded(false))
   }, [project])
 
   const renderTabContent = () => {
@@ -71,9 +76,10 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
     tabId: string
     label: string
     icon: React.ComponentType<LucideProps>
+    badge?: boolean
   }
 
-  const TabButton: React.FC<TabButtonProps> = ({ tabId, label, icon: Icon }) => (
+  const TabButton: React.FC<TabButtonProps> = ({ tabId, label, icon: Icon, badge }) => (
     <button
       onClick={() => setActiveTab(tabId)}
       className={`flex flex-1 flex-shrink-0 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
@@ -84,6 +90,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
     >
       <Icon size={18} className="mr-2" />
       {label}
+      {badge && <Badge variant="destructive" className="ml-1">!</Badge>}
     </button>
   )
 
@@ -106,7 +113,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
       <div className="mb-6 border-b border-gray-200">
         <nav className="flex space-x-2 overflow-x-auto whitespace-nowrap pb-2" aria-label="Tabs">
           <TabButton tabId="overview" label="Overview" icon={ChartNoAxesCombined} />
-          <TabButton tabId="tasks" label="Tasks" icon={Calendar} />
+          <TabButton tabId="tasks" label="Tasks" icon={Calendar} badge={attentionNeeded} />
           <TabButton tabId="topics" label="Topics" icon={Tags} />
           <TabButton tabId="documents" label="Documents" icon={FileText} />
         </nav>

--- a/app/src/components/views/ProjectDetailView.tsx
+++ b/app/src/components/views/ProjectDetailView.tsx
@@ -82,7 +82,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
   const TabButton: React.FC<TabButtonProps> = ({ tabId, label, icon: Icon, badge }) => (
     <button
       onClick={() => setActiveTab(tabId)}
-      className={`flex flex-1 flex-shrink-0 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
+      className={`relative flex flex-1 flex-shrink-0 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
         activeTab === tabId
           ? 'bg-blue-100 text-blue-700'
           : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
@@ -90,7 +90,14 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
     >
       <Icon size={18} className="mr-2" />
       {label}
-      {badge && <Badge variant="destructive" className="ml-1">!</Badge>}
+      {badge && (
+        <Badge
+          variant="destructive"
+          className="pointer-events-none absolute -top-1 -right-1 px-1 py-0 text-xs"
+        >
+          !
+        </Badge>
+      )}
     </button>
   )
 

--- a/app/src/components/views/ProjectDetailView.tsx
+++ b/app/src/components/views/ProjectDetailView.tsx
@@ -93,7 +93,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
       {badge && (
         <Badge
           variant="destructive"
-          className="pointer-events-none absolute -top-1 -right-1 px-1 py-0 text-xs"
+          className="pointer-events-none absolute -top-1 -right-1 w-4 h-4 text-xs flex items-center justify-center rounded-full p-0"
         >
           !
         </Badge>
@@ -118,7 +118,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
         </button>
       </div>
       <div className="mb-6 border-b border-gray-200">
-        <nav className="flex space-x-2 overflow-x-auto whitespace-nowrap pb-2" aria-label="Tabs">
+        <nav className="flex space-x-2 overflow-visible whitespace-nowrap pb-2" aria-label="Tabs">
           <TabButton tabId="overview" label="Overview" icon={ChartNoAxesCombined} />
           <TabButton tabId="tasks" label="Tasks" icon={Calendar} badge={attentionNeeded} />
           <TabButton tabId="topics" label="Topics" icon={Tags} />

--- a/app/src/models/Goal.ts
+++ b/app/src/models/Goal.ts
@@ -110,10 +110,16 @@ export class Goal {
     /**
      * Loads the goal's main markdown note.
      */
-    async getOverview(): Promise<string> {
-        const res = await DocumentHandler.getInstance().getDocument(
-            `${this.id}/${this.id}.md`
-        );
-        return res.content || '';
-    }
+  async getOverview(): Promise<string> {
+    const res = await DocumentHandler.getInstance().getDocument(
+      `${this.id}/${this.id}.md`
+    );
+    return res.content || '';
+  }
+
+  hasAttentionTask(): boolean {
+    return this.tasks.some(
+      t => t.status === 'attention' && !t.completedAt,
+    );
+  }
 }

--- a/app/src/models/Project.ts
+++ b/app/src/models/Project.ts
@@ -2,6 +2,8 @@ import { Status } from "./Status";
 import { Goal } from "./Goal";
 import { APP_CONFIG } from "../utils/appConfig";
 import { DocumentHandler } from "./DocumentHandler";
+import { TaskHandler } from "./TaskHandler";
+import { AutomatedTask } from "./Task";
 
 export class Project {
   id: string;
@@ -110,10 +112,17 @@ export class Project {
     /**
      * Loads the project's main markdown note.
      */
-    async getOverview(): Promise<string> {
-        const res = await DocumentHandler.getInstance().getDocument(
-            `${this.goal.id}/${this.id}/${this.id}.md`
-        );
-        return res.content || '';
-    }
+  async getOverview(): Promise<string> {
+    const res = await DocumentHandler.getInstance().getDocument(
+      `${this.goal.id}/${this.id}/${this.id}.md`
+    );
+    return res.content || '';
+  }
+
+  async hasAttentionTask(): Promise<boolean> {
+    const tasks = await TaskHandler.getInstance().getTasksForProject(this.id);
+    return tasks.some(
+      t => t instanceof AutomatedTask && t.status === 'attention' && !t.completedAt,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add `hasAttentionTask` helper to goal and project models
- highlight task tabs when any automated task needs attention

## Testing
- `npm run lint` *(fails: React must be in scope and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856dbdc7430832bb2eb3d09a8c8eaef