### PR TITLE
Fix goal tasks persistence

### DIFF
--- a/app/src/components/tabs/goal/TaskTab.tsx
+++ b/app/src/components/tabs/goal/TaskTab.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Goal } from '@/models/Goal';
 import { AutomatedTask, AutomationState } from '@/models/Task';
+import { TaskHandler } from '@/models/TaskHandler';
 import { StatusIndicator } from '@/components/ui/status-indicator';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import Modal from '@/components/ui/modal';
@@ -24,6 +25,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ goal }) => {
   const [tasks, setTasks] = useState<AutomatedTask[]>([]);
   const [activeChat, setActiveChat] = useState<Chat | null>(null);
   const [showTimeline, setShowTimeline] = useState(false);
+  const handler = React.useMemo(() => TaskHandler.getInstance(), []);
 
   const sortTasks = (list: AutomatedTask[]) =>
     [...list].sort((a, b) => {
@@ -34,7 +36,11 @@ const TaskTab: React.FC<TaskTabProps> = ({ goal }) => {
 
   useEffect(() => {
     setTasks(sortTasks(goal.tasks ?? []));
-  }, [goal]);
+    handler
+      .getTasksForGoal(goal.id)
+      .then(list => setTasks(sortTasks(list)))
+      .catch(() => {})
+  }, [goal.id, handler])
 
   const openTask = (task: AutomatedTask) => {
     const dummyProject = new Project(

--- a/app/src/components/views/GoalDetailView.tsx
+++ b/app/src/components/views/GoalDetailView.tsx
@@ -19,6 +19,7 @@ import DocumentTab from '../tabs/goal/DocumentTab';
 import { Goal } from '@/models/Goal';
 import { Badge } from '@/components/ui/badge';
 import { GoalHandler } from '@/models/GoalHandler';
+import { TaskHandler } from '@/models/TaskHandler';
 
 interface GoalDetailViewProps {
   goal: Goal;
@@ -36,14 +37,28 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showChat, setShowChat] = useState(false);
-
-  const attentionNeeded = editedGoal.hasAttentionTask();
+  const [attentionNeeded, setAttentionNeeded] = useState(false);
+  const handler = React.useMemo(() => TaskHandler.getInstance(), []);
 
   useEffect(() => {
     setEditedGoal(goal);
     setIsEditing(false);
     setActiveTab('overview');
-  }, [goal]);
+    handler
+      .getTasksForGoal(goal.id)
+      .then(list => {
+        setEditedGoal(g => {
+          g.tasks = list
+          return { ...g }
+        })
+        setAttentionNeeded(
+          list.some(t => t.status === 'attention' && !t.completedAt)
+        )
+      })
+      .catch(() => {
+        setAttentionNeeded(false)
+      })
+  }, [goal, handler]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;

--- a/app/src/models/TaskHandler.ts
+++ b/app/src/models/TaskHandler.ts
@@ -103,4 +103,27 @@ export class TaskHandler {
       return new ManualTask(...common)
     })
   }
+
+  async getTasksForGoal(goalId: string): Promise<AutomatedTask[]> {
+    const { data, error } = await supabase
+      .from('tasks')
+      .select('*')
+      .eq('goal_id', goalId)
+    if (error || !data) return []
+    return data
+      .filter(t => t.is_automated)
+      .map(t =>
+        new AutomatedTask(
+          t.id,
+          t.name,
+          t.description ?? '',
+          new Date(t.deadline),
+          null,
+          t.duration,
+          t.status as AutomationState,
+          [],
+          t.completed_at ? new Date(t.completed_at) : null
+        )
+      )
+  }
 }


### PR DESCRIPTION
## Summary
- add `getTasksForGoal` in TaskHandler
- load tasks in Goal TaskTab using TaskHandler
- fetch goal tasks on detail view to show badge

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856e183401c832b951208e04d154411