### PR TITLE
Implement setup chat on habit page

### DIFF
--- a/app/src/components/views/SetupChatView.tsx
+++ b/app/src/components/views/SetupChatView.tsx
@@ -1,0 +1,144 @@
+import React, { useState, useRef, useEffect } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import axios from 'axios'
+import { XCircle } from 'lucide-react'
+import ChatBubble from '@/components/ui/chat-bubble'
+import CleanChatBubble from '@/components/ui/clean-chat-bubble'
+import ChatTextField from '../ui/chat-text-field'
+import TypingIndicator from '../ui/typing-indicator'
+
+interface ChatMessage {
+  sender: 'user' | 'assistant'
+  text: string
+  isError?: boolean
+}
+
+interface SetupChatViewProps {
+  goalId: string
+}
+
+const SetupChatView: React.FC<SetupChatViewProps> = ({ goalId }) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  const handleSubmit = async (text: string) => {
+    if (!text.trim()) return
+    setMessages(prev => [...prev, { sender: 'user', text }])
+    setIsLoading(true)
+    const url = import.meta.env.VITE_SETUP_AGENT_WEBHOOK
+    if (!url) {
+      setMessages(prev => [
+        ...prev,
+        { sender: 'assistant', text: 'Setup agent webhook not configured.' },
+      ])
+      setIsLoading(false)
+      return
+    }
+    try {
+      const response = await axios.post(
+        url,
+        { session_id: goalId, chat_input: text },
+        { headers: { 'Content-Type': 'application/json' } }
+      )
+      const answer =
+        response.data?.output ||
+        response.data?.text ||
+        response.data?.message ||
+        (typeof response.data === 'string'
+          ? response.data
+          : JSON.stringify(response.data))
+      setMessages(prev => [...prev, { sender: 'assistant', text: answer }])
+    } catch (err) {
+      /* eslint-disable no-console */
+      console.error(err)
+      setMessages(prev => [
+        ...prev,
+        {
+          sender: 'assistant',
+          text: 'Failed to get a response',
+          isError: true,
+        },
+      ])
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    if ((window as any).MathJax?.typeset) {
+      ;(window as any).MathJax.typeset()
+    }
+  }, [messages])
+
+  return (
+    <div className="flex flex-col h-[60vh]">
+      <div className="flex flex-col flex-grow space-y-2 text-sm overflow-y-auto mb-2">
+        {messages.map((m, idx) => (
+          <div
+            key={idx}
+            className={`flex ${m.sender === 'user' ? 'justify-end' : 'justify-start'}`}
+          >
+            {m.sender === 'user' ? (
+              <ChatBubble>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    table: props => (
+                      <table className="min-w-full border border-gray-300 text-sm" {...props} />
+                    ),
+                    th: props => (
+                      <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
+                    ),
+                    td: props => <td className="border px-2 py-1" {...props} />,
+                  }}
+                >
+                  {m.text}
+                </ReactMarkdown>
+              </ChatBubble>
+            ) : (
+              <CleanChatBubble>
+                {m.isError ? (
+                  <div className="flex items-center gap-2 rounded-3xl bg-red-50 border border-red-200 text-red-800 p-2">
+                    <XCircle className="w-4 h-4" />
+                    <span>{m.text}</span>
+                  </div>
+                ) : (
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                      table: props => (
+                        <table className="min-w-full border border-gray-300 text-sm" {...props} />
+                      ),
+                      th: props => (
+                        <th className="border px-2 py-1 bg-gray-100 text-left" {...props} />
+                      ),
+                      td: props => <td className="border px-2 py-1" {...props} />,
+                    }}
+                  >
+                    {m.text}
+                  </ReactMarkdown>
+                )}
+              </CleanChatBubble>
+            )}
+          </div>
+        ))}
+        {isLoading && (
+          <div className="flex justify-start">
+            <CleanChatBubble>
+              <TypingIndicator />
+            </CleanChatBubble>
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+      <div className="sticky bottom-0 bg-white pt-2">
+        <ChatTextField onSubmit={handleSubmit} />
+      </div>
+    </div>
+  )
+}
+
+export default SetupChatView

--- a/app/src/models/GoalHandler.ts
+++ b/app/src/models/GoalHandler.ts
@@ -45,6 +45,16 @@ export class GoalHandler {
     )
   }
 
+  async createGoalStub(id: string, name: string): Promise<void> {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return
+    await supabase
+      .from('goals')
+      .insert({ id, user_id: user.id, name })
+  }
+
   async deleteGoal(id: string): Promise<void> {
     const projectHandler = ProjectHandler.getInstance()
     const projects = await projectHandler.getProjectsForGoal(id)

--- a/app/src/pages/HabitPage.tsx
+++ b/app/src/pages/HabitPage.tsx
@@ -1,9 +1,43 @@
-export default function HabitPage() {
+import { useState } from 'react'
+import { Goal } from '@/models/Goal'
+import { GoalHandler } from '@/models/GoalHandler'
+import { AOL } from '@/models/AOL'
+import Modal from '@/components/ui/modal'
+import SetupChatView from '@/components/views/SetupChatView'
 
+export default function HabitPage() {
+  const [sessionGoalId, setSessionGoalId] = useState<string | null>(null)
+
+  const handleClick = async () => {
+    const today = new Date()
+    const goal = new Goal(
+      crypto.randomUUID(),
+      'test',
+      '',
+      0,
+      0,
+      0,
+      [today, today],
+      AOL.GROWTH,
+      []
+    )
+    await GoalHandler.getInstance().createGoal(goal)
+    setSessionGoalId(goal.id)
+  }
+
+  const closeModal = () => setSessionGoalId(null)
 
   return (
     <>
-      <button>Primary</button>
+      <button
+        onClick={handleClick}
+        className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+      >
+        Primary
+      </button>
+      <Modal isOpen={!!sessionGoalId} onClose={closeModal} title="">
+        {sessionGoalId && <SetupChatView goalId={sessionGoalId} />}
+      </Modal>
     </>
-  );
+  )
 }

--- a/app/src/pages/HabitPage.tsx
+++ b/app/src/pages/HabitPage.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react'
-import { Goal } from '@/models/Goal'
 import { GoalHandler } from '@/models/GoalHandler'
-import { AOL } from '@/models/AOL'
 import Modal from '@/components/ui/modal'
 import SetupChatView from '@/components/views/SetupChatView'
 
@@ -9,20 +7,9 @@ export default function HabitPage() {
   const [sessionGoalId, setSessionGoalId] = useState<string | null>(null)
 
   const handleClick = async () => {
-    const today = new Date()
-    const goal = new Goal(
-      crypto.randomUUID(),
-      'test',
-      '',
-      0,
-      0,
-      0,
-      [today, today],
-      AOL.GROWTH,
-      []
-    )
-    await GoalHandler.getInstance().createGoal(goal)
-    setSessionGoalId(goal.id)
+    const id = crypto.randomUUID()
+    await GoalHandler.getInstance().createGoalStub(id, 'test')
+    setSessionGoalId(id)
   }
 
   const closeModal = () => setSessionGoalId(null)


### PR DESCRIPTION
## Summary
- style habit page button with Tailwind
- create a new goal named `test` when button clicked
- add a SetupChatView component that talks to `VITE_SETUP_AGENT_WEBHOOK`
- open chat modal after goal creation

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859b4e4b8a0832bb6ac095c7e872105