### PR TITLE
test: expand coverage for core utilities and models

### DIFF
--- a/app/src/models/Goal.test.ts
+++ b/app/src/models/Goal.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('./DocumentHandler', () => ({
+  DocumentHandler: { getInstance: () => ({ getDocument: vi.fn() }) }
+}))
+
+import { Goal } from './Goal'
+import { AOL } from './AOL'
+import { Status } from './Status'
+import { AutomatedTask } from './Task'
+
+const startDate = new Date('2024-01-01')
+const endDate = new Date('2024-01-11')
+
+function createGoal(current: number, tasks: AutomatedTask[] = []) {
+  return new Goal('1', 'Test', 'desc', 0, current, 100, [startDate, endDate], AOL.GROWTH, tasks)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2024-01-06'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('Goal metrics', () => {
+  test('calculates progress and time correctly', () => {
+    const goal = createGoal(50)
+    expect(goal.progressPercentage).toBe(50)
+    expect(goal.totalDays).toBe(10)
+    expect(goal.daysElapsed).toBe(5)
+    expect(goal.daysRemaining).toBe(5)
+    expect(goal.timePercentage).toBe(50)
+  })
+})
+
+describe('Goal status', () => {
+  test('determines status based on progress and time', () => {
+    expect(createGoal(60).status).toBe(Status.ON_TRACK)
+    expect(createGoal(47).status).toBe(Status.AT_RISK)
+    expect(createGoal(40).status).toBe(Status.OFF_TRACK)
+    expect(createGoal(100).status).toBe(Status.ACHIEVED)
+    vi.setSystemTime(new Date('2023-12-30'))
+    expect(createGoal(0).status).toBe(Status.NOT_STARTED)
+  })
+})
+
+describe('Goal tasks', () => {
+  test('hasAttentionTask detects active attention tasks', () => {
+    const task = new AutomatedTask('t1', 'Task', '', new Date(), null, 0, 'attention')
+    const goal = createGoal(0, [task])
+    expect(goal.hasAttentionTask()).toBe(true)
+  })
+})

--- a/app/src/styles/statusStyles.test.ts
+++ b/app/src/styles/statusStyles.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from 'vitest'
+import { containerStyle, statusLabelStyle } from './statusStyles'
+import { Status } from '@/models/Status'
+
+test('containerStyle defines classes for all statuses', () => {
+  expect(containerStyle[Status.ON_TRACK]).toBe('bg-green-50 border border-green-200')
+  expect(containerStyle[Status.AT_RISK]).toBe('bg-yellow-50 border border-yellow-200')
+  expect(containerStyle[Status.OFF_TRACK]).toBe('bg-red-50 border border-red-200')
+  expect(containerStyle[Status.NOT_STARTED]).toBe('bg-gray-50 border border-gray-200')
+  expect(containerStyle[Status.ACHIEVED]).toBe('bg-blue-50 border border-blue-200')
+})
+
+test('statusLabelStyle defines text colors for statuses', () => {
+  expect(statusLabelStyle[Status.ON_TRACK]).toBe('bg-green-200 text-green-800')
+  expect(statusLabelStyle[Status.AT_RISK]).toBe('bg-yellow-200 text-yellow-800')
+  expect(statusLabelStyle[Status.OFF_TRACK]).toBe('bg-red-200 text-red-800')
+  expect(statusLabelStyle[Status.NOT_STARTED]).toBe('bg-gray-200 text-gray-800')
+  expect(statusLabelStyle[Status.ACHIEVED]).toBe('bg-blue-200 text-blue-800')
+})

--- a/app/src/utils/appConfig.test.ts
+++ b/app/src/utils/appConfig.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, test, expect } from 'vitest'
+import { APP_CONFIG, loadWorkweekConfig, saveWorkweekConfig, type WorkweekConfig } from './appConfig'
+
+beforeEach(() => {
+  localStorage.clear()
+  APP_CONFIG.workweek = { days: ['Mon', 'Tue'], start: '08:00', end: '17:00' }
+})
+
+test('loadWorkweekConfig populates APP_CONFIG from localStorage', () => {
+  const config: WorkweekConfig = { days: ['Fri'], start: '09:00', end: '18:00' }
+  localStorage.setItem('workweek', JSON.stringify(config))
+  loadWorkweekConfig()
+  expect(APP_CONFIG.workweek).toEqual(config)
+})
+
+test('saveWorkweekConfig stores config to localStorage', () => {
+  const config: WorkweekConfig = { days: ['Wed'], start: '10:00', end: '15:00' }
+  saveWorkweekConfig(config)
+  expect(APP_CONFIG.workweek).toEqual(config)
+  expect(JSON.parse(localStorage.getItem('workweek')!)).toEqual(config)
+})

--- a/app/src/utils/formatDate.test.ts
+++ b/app/src/utils/formatDate.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from 'vitest'
+import { formatDate } from './formatDate'
+
+test('formatDate returns dd.mm.yyyy in de-DE locale', () => {
+  const date = new Date('2024-12-11')
+  expect(formatDate(date)).toBe('11.12.2024')
+})

--- a/app/supabase.test.ts
+++ b/app/supabase.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect, beforeAll } from 'vitest'
+
+const requiredEnv = ['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY']
+const missing = requiredEnv.filter(k => !process.env[k])
+
+if (missing.length) {
+  describe.skip('supabase backend', () => {
+    test('skipped: missing environment configuration', () => {})
+  })
+} else {
+  describe('supabase backend', () => {
+    let supabase: any
+
+    beforeAll(async () => {
+      supabase = (await import('./supabase')).default
+    })
+
+    test('connects successfully', async () => {
+      const { error } = await supabase.auth.getSession()
+      expect(error).toBeNull()
+    })
+
+    const tables = ['doc_emb', 'doc_metadata', 'doc_rows', 'goals', 'projects', 'tasks', 'topics']
+    tables.forEach(table => {
+      test(`table ${table} exists`, async () => {
+        const { error } = await supabase.from(table).select('*').limit(1)
+        expect(error).toBeNull()
+      })
+    })
+  })
+}

--- a/app/supabase.test.ts
+++ b/app/supabase.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeAll } from 'vitest'
 
 const requiredEnv = ['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY']
-const missing = requiredEnv.filter(k => !process.env[k])
+const missing = requiredEnv.filter(k => !import.meta.env[k as keyof ImportMetaEnv])
 
 if (missing.length) {
   describe.skip('supabase backend', () => {


### PR DESCRIPTION
## Summary
- add unit tests for date formatting helper
- add tests for workweek config loading and saving
- verify status style mappings
- cover Goal model metrics, status transitions, and task checks
- add connectivity checks to Supabase backend and ensure required tables exist

## Testing
- `npm test`
- `npm run lint` *(fails: 'React' must be in scope when using JSX, Mixed spaces and tabs)*

------
https://chatgpt.com/codex/tasks/task_e_689db42d346c832b9155c7539ed8816f