### PR TITLE
Revamp dashboard and navigation styling

### DIFF
--- a/app/src/components/ui/app-shell.tsx
+++ b/app/src/components/ui/app-shell.tsx
@@ -1,4 +1,5 @@
 'use client';
+import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Menu, X, LogOut, ListTodo, Settings, Target, Repeat, Home } from 'lucide-react';
 import supabase from '../../../supabase';
@@ -18,9 +19,9 @@ function ShellInner({ children }: { children: React.ReactNode }) {
   return (
     <div className="relative h-screen flex flex-col md:flex-row overflow-hidden">
       {/* ----- mobile top bar ----- */}
-      <div className="md:hidden flex justify-between items-center p-4 bg-white border-b sticky top-0 z-20">
-        <h1 className="text-lg font-bold text-blue-700">Lifemanager</h1>
-        <Button variant="ghost" size="icon" onClick={() => setIsSidebarOpen(true)}>
+      <div className="md:hidden flex justify-between items-center p-4 bg-blue-600 text-white sticky top-0 z-20">
+        <h1 className="text-lg font-bold">Lifemanager</h1>
+        <Button variant="ghost" size="icon" onClick={() => setIsSidebarOpen(true)} className="text-white">
           <Menu className="h-6 w-6" />
         </Button>
       </div>
@@ -35,18 +36,18 @@ function ShellInner({ children }: { children: React.ReactNode }) {
 
       {/* ----- sidebar ----- */}
       <nav
-        className={`fixed inset-y-0 left-0 z-40 w-64 bg-white border-r p-4 flex flex-col transform transition-transform duration-300
+        className={`fixed inset-y-0 left-0 z-40 w-64 bg-gray-800 text-white p-4 flex flex-col transform transition-transform duration-300
         md:static md:translate-x-0 ${
           isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
         {/* header + close btn */}
         <div className="px-2 mb-8 flex justify-between items-center">
-          <h1 className="text-xl font-bold text-blue-700 hidden md:block">Lifemanager</h1>
+          <h1 className="text-xl font-bold hidden md:block">Lifemanager</h1>
           <Button
             variant="ghost"
             size="icon"
-            className="md:hidden"
+            className="md:hidden text-white"
             onClick={() => setIsSidebarOpen(false)}
           >
             <X className="h-6 w-6" />
@@ -61,11 +62,11 @@ function ShellInner({ children }: { children: React.ReactNode }) {
               <button
                 key={name}
                 onClick={() => {
-                  setActiveTab(name as any);
+                  setActiveTab(name);
                   if (window.innerWidth < 768) setIsSidebarOpen(false);
                 }}
                 className={`w-full flex items-center px-3 py-2.5 rounded-md text-sm font-medium
-                  ${active ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'}`}
+                  ${active ? 'bg-gray-900 text-white' : 'text-gray-300 hover:bg-gray-700 hover:text-white'}`}
               >
                 <Icon className="w-5 h-5 mr-3" />
                 {name}
@@ -75,7 +76,7 @@ function ShellInner({ children }: { children: React.ReactNode }) {
         </div>
 
         {/* logout */}
-        <div className="mt-auto pt-4 border-t">
+        <div className="mt-auto pt-4 border-t border-gray-700">
         <button
             onClick={() => {
               setActiveTab('Settings');
@@ -83,8 +84,8 @@ function ShellInner({ children }: { children: React.ReactNode }) {
             }}
             className={`w-full flex items-center px-3 py-2.5 rounded-md text-sm ${
               activeTab === 'Settings'
-                ? 'bg-blue-50 text-blue-700'
-                : 'text-gray-600 hover:bg-gray-100'
+                ? 'bg-gray-900 text-white'
+                : 'text-gray-300 hover:bg-gray-700 hover:text-white'
             }`}
           >
             <Settings className="w-5 h-5 mr-3" />
@@ -92,7 +93,7 @@ function ShellInner({ children }: { children: React.ReactNode }) {
           </button>
           <button
             onClick={() => supabase.auth.signOut()}
-            className="w-full flex items-center px-3 py-2.5 rounded-md text-sm text-gray-600 hover:bg-gray-100"
+            className="w-full flex items-center px-3 py-2.5 rounded-md text-sm text-gray-300 hover:bg-gray-700 hover:text-white"
           >
             <LogOut className="w-5 h-5 mr-3" />
             Logout

--- a/app/src/pages/HomePage.tsx
+++ b/app/src/pages/HomePage.tsx
@@ -1,12 +1,55 @@
 import React from 'react';
+import { Repeat, ListTodo, Target } from 'lucide-react';
+import { useAppShell } from '@/components/ui/app-shell-context';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 
 export default function HomePage() {
+  const { setActiveTab } = useAppShell();
+  const features = [
+    {
+      name: 'Habits',
+      description: 'Build consistent routines and track daily progress.',
+      icon: Repeat,
+      tab: 'Habits',
+    },
+    {
+      name: 'Projects',
+      description: 'Organise work into actionable tasks.',
+      icon: ListTodo,
+      tab: 'Projects',
+    },
+    {
+      name: 'Goals',
+      description: 'Track long-term objectives and progress.',
+      icon: Target,
+      tab: 'Goals',
+    },
+  ] as const;
+
   return (
-    <section className="bg-white p-4 sm:p-6 rounded-lg shadow space-y-2">
-      <h1 className="text-2xl font-bold">Welcome to LifeManager</h1>
-      <p className="text-gray-700">
-        Manage your habits, projects and goals from a single dashboard.
-      </p>
+    <section className="space-y-6">
+      <h1 className="text-xl font-bold">Dashboard</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {features.map(({ name, description, icon: Icon, tab }) => (
+          <Card
+            key={name}
+            className="bg-white shadow rounded p-4 text-gray-800 flex flex-col"
+          >
+            <div className="flex items-center mb-2">
+              <Icon className="w-6 h-6 text-blue-600 mr-2" />
+              <h2 className="text-lg font-semibold">{name}</h2>
+            </div>
+            <p className="text-sm flex-1 text-gray-600">{description}</p>
+            <Button
+              className="mt-4 px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 self-start"
+              onClick={() => setActiveTab(tab)}
+            >
+              Open
+            </Button>
+          </Card>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- modernize navigation with blue header and dark sidebar for better contrast and responsiveness
- introduce responsive dashboard cards for quick access to Habits, Projects, and Goals

## Testing
- `npm run lint` *(fails: 'React' must be in scope when using JSX across existing files)*
- `npx eslint app/src/components/ui/app-shell.tsx app/src/pages/HomePage.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eee30b9cc832b807cf1edccd89cb0