### PR TITLE
Handle Supabase errors with toast notifications

### DIFF
--- a/app/src/models/GoalHandler.ts
+++ b/app/src/models/GoalHandler.ts
@@ -3,6 +3,7 @@ import { Goal } from './Goal'
 import { DocumentHandler } from './DocumentHandler'
 import { MOCK_MARKDOWN } from '../utils/mockMarkdown'
 import { ProjectHandler } from './ProjectHandler'
+import { toast } from '../hooks/use-toast'
 
 export class GoalHandler {
   private static instance: GoalHandler | null = null
@@ -19,51 +20,75 @@ export class GoalHandler {
   private constructor() {}
 
   async createGoal(goal: Goal): Promise<void> {
-    const { data: { user } } = await supabase.auth.getUser()
-    if (!user) return
-    const { data: inserted, error } = await supabase
-      .from('goals')
-      .insert({
-      user_id: user.id,
-      name: goal.name,
-      description: goal.description,
-      start: goal.start,
-      current: goal.current,
-      objective: goal.objective,
-      period_from: goal.period[0].toISOString().slice(0,10),
-      period_to: goal.period[1].toISOString().slice(0,10),
-      status: goal.status,
-      area_of_life: goal.aol,
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) return
+      const { data: inserted, error } = await supabase
+        .from('goals')
+        .insert({
+        user_id: user.id,
+        name: goal.name,
+        description: goal.description,
+        start: goal.start,
+        current: goal.current,
+        objective: goal.objective,
+        period_from: goal.period[0].toISOString().slice(0,10),
+        period_to: goal.period[1].toISOString().slice(0,10),
+        status: goal.status,
+        area_of_life: goal.aol,
+        })
+        .select()
+        .single()
+      if (error || !inserted) throw error || new Error('Goal creation failed')
+      goal.id = inserted.id
+      await DocumentHandler.getInstance().uploadMarkdown(
+        `${goal.id}/${goal.id}.md`,
+        MOCK_MARKDOWN
+      )
+    } catch (err: unknown) {
+      toast({
+        title: 'Error creating goal',
+        description: err instanceof Error ? err.message : 'Unknown error',
       })
-      .select()
-      .single()
-    if (error || !inserted) return
-    goal.id = inserted.id
-    await DocumentHandler.getInstance().uploadMarkdown(
-      `${goal.id}/${goal.id}.md`,
-      MOCK_MARKDOWN
-    )
+    }
   }
 
   async deleteGoal(id: string): Promise<void> {
-    const projectHandler = ProjectHandler.getInstance()
-    const projects = await projectHandler.getProjectsForGoal(id)
-    await Promise.all(projects.map(p => projectHandler.deleteProject(p.id)))
-    await DocumentHandler.getInstance().deleteFolder(`${id}`)
-    await supabase.from('goals').delete().eq('id', id)
+    try {
+      const projectHandler = ProjectHandler.getInstance()
+      const projects = await projectHandler.getProjectsForGoal(id)
+      await Promise.all(projects.map(p => projectHandler.deleteProject(p.id)))
+      await DocumentHandler.getInstance().deleteFolder(`${id}`)
+      const { error } = await supabase.from('goals').delete().eq('id', id)
+      if (error) throw error
+    } catch (err: unknown) {
+      toast({
+        title: 'Error deleting goal',
+        description: err instanceof Error ? err.message : 'Unknown error',
+      })
+    }
   }
 
   async getGoals(): Promise<Goal[]> {
-    const { data } = await supabase.from('goals').select('*')
-    return (data || []).map(g => new Goal(
-      g.id,
-      g.name,
-      g.description,
-      g.start,
-      g.current,
-      g.objective,
-      [new Date(g.period_from), new Date(g.period_to)],
-      g.area_of_life,
-    ))
+    try {
+      const { data, error } = await supabase.from('goals').select('*')
+      if (error || !data) throw error || new Error('Failed to load goals')
+      return data.map(g => new Goal(
+        g.id,
+        g.name,
+        g.description,
+        g.start,
+        g.current,
+        g.objective,
+        [new Date(g.period_from), new Date(g.period_to)],
+        g.area_of_life,
+      ))
+    } catch (err: unknown) {
+      toast({
+        title: 'Error fetching goals',
+        description: err instanceof Error ? err.message : 'Unknown error',
+      })
+      return []
+    }
   }
 }


### PR DESCRIPTION
## Summary
- wrap goal creation/deletion/fetching in try/catch blocks and notify on failure
- add error handling and toast notifications around document storage operations

## Testing
- `npm run lint` *(fails: 264 errors in existing files)*
- `npx eslint app/src/models/GoalHandler.ts app/src/models/DocumentHandler.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ef3c0341c832b896fe8110b8e4df7