### PR TITLE
Add unit tests for document and goal handlers

### DIFF
--- a/app/src/models/DocumentHandler.test.ts
+++ b/app/src/models/DocumentHandler.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+
+const {
+  authGetUser,
+  upload,
+  download,
+  remove,
+  list,
+  storageFrom,
+  post,
+} = vi.hoisted(() => {
+  const upload = vi.fn()
+  const download = vi.fn()
+  const remove = vi.fn()
+  const list = vi.fn()
+  return {
+    authGetUser: vi.fn(),
+    upload,
+    download,
+    remove,
+    list,
+    storageFrom: vi.fn(() => ({ upload, download, remove, list })),
+    post: vi.fn(),
+  }
+})
+
+vi.mock('../../supabase', () => ({
+  default: {
+    auth: { getUser: authGetUser },
+    storage: { from: storageFrom },
+  },
+}))
+
+vi.mock('axios', () => ({ default: { post } }))
+
+import { DocumentHandler } from './DocumentHandler'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  DocumentHandler.reset()
+  authGetUser.mockResolvedValue({ data: { user: { id: 'user1' } } })
+  storageFrom.mockReturnValue({ upload, download, remove, list })
+  upload.mockResolvedValue({})
+  remove.mockResolvedValue({})
+  post.mockResolvedValue({})
+  vi.stubEnv('VITE_DOCUMENT_ENCODING_WEBHOOK', 'https://webhook.example.com')
+  vi.stubEnv('VITE_SUPABASE_STORAGE_URL', 'https://storage.example.com')
+})
+
+describe('DocumentHandler', () => {
+  test('uploadDocument uploads file and triggers webhook', async () => {
+    const handler = DocumentHandler.getInstance()
+    const file = new File(['hello'], 'file.txt', { type: 'text/plain' })
+
+    await handler.uploadDocument('g1/p1/file.txt', file)
+
+    expect(storageFrom).toHaveBeenCalledWith('documents')
+    expect(upload).toHaveBeenCalledWith('user1/g1/p1/file.txt', file, { upsert: true })
+    expect(post).toHaveBeenCalledWith(
+      'https://webhook.example.com',
+      {
+        id: 'user1/g1/p1/file.txt',
+        title: 'file.txt',
+        type: 'text/plain',
+        url: 'https://storage.example.com/documents/user1/g1/p1/file.txt',
+        project_id: 'p1',
+      },
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  })
+
+  test('getDocument downloads text content', async () => {
+    const data = { text: () => Promise.resolve('content') } as any
+    download.mockResolvedValue({ data, error: null })
+    const handler = DocumentHandler.getInstance()
+
+    const res = await handler.getDocument('g1/note.txt')
+
+    expect(download).toHaveBeenCalledWith('user1/g1/note.txt')
+    expect(res).toEqual({ name: 'note.txt', type: 'txt', content: 'content' })
+  })
+
+  test('deleteFolder removes all files under prefix', async () => {
+    const handler = DocumentHandler.getInstance()
+    const listSpy = vi
+      .spyOn(handler as any, 'listFilePaths')
+      .mockResolvedValue(['user1/g1/f1.txt', 'user1/g1/f2.txt'])
+
+    await handler.deleteFolder('g1')
+
+    expect(listSpy).toHaveBeenCalledWith('user1/g1')
+    expect(remove).toHaveBeenCalledWith(['user1/g1/f1.txt', 'user1/g1/f2.txt'])
+    listSpy.mockRestore()
+  })
+})
+

--- a/app/src/models/GoalHandler.test.ts
+++ b/app/src/models/GoalHandler.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { Goal } from './Goal'
+import { AOL } from './AOL'
+import { GoalHandler } from './GoalHandler'
+import { MOCK_MARKDOWN } from '../utils/mockMarkdown'
+
+const {
+  authGetUser,
+  single,
+  select,
+  insert,
+  eq,
+  del,
+  from,
+  uploadMarkdown,
+  deleteFolder,
+  getProjectsForGoal,
+  deleteProject,
+} = vi.hoisted(() => {
+  const single = vi.fn()
+  const select = vi.fn(() => ({ single }))
+  const insert = vi.fn(() => ({ select }))
+  const eq = vi.fn()
+  const del = vi.fn(() => ({ eq }))
+  const from = vi.fn(() => ({ insert, delete: del }))
+  return {
+    authGetUser: vi.fn(),
+    single,
+    select,
+    insert,
+    eq,
+    del,
+    from,
+    uploadMarkdown: vi.fn(),
+    deleteFolder: vi.fn(),
+    getProjectsForGoal: vi.fn(),
+    deleteProject: vi.fn(),
+  }
+})
+
+vi.mock('../../supabase', () => ({ default: { auth: { getUser: authGetUser }, from } }))
+
+vi.mock('./DocumentHandler', () => ({
+  DocumentHandler: { getInstance: () => ({ uploadMarkdown, deleteFolder }) },
+}))
+
+vi.mock('./ProjectHandler', () => ({
+  ProjectHandler: { getInstance: () => ({ getProjectsForGoal, deleteProject }) },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  GoalHandler.reset()
+})
+
+describe('GoalHandler', () => {
+  test('createGoal inserts goal and uploads markdown', async () => {
+    authGetUser.mockResolvedValue({ data: { user: { id: 'user1' } } })
+    single.mockResolvedValue({ data: { id: 'g1' }, error: null })
+    const goal = new Goal('', 'Goal', 'desc', 0, 0, 10, [new Date(), new Date()], AOL.GROWTH)
+
+    await GoalHandler.getInstance().createGoal(goal)
+
+    expect(insert).toHaveBeenCalled()
+    expect(goal.id).toBe('g1')
+    expect(uploadMarkdown).toHaveBeenCalledWith('g1/g1.md', MOCK_MARKDOWN)
+  })
+
+  test('deleteGoal removes related data', async () => {
+    getProjectsForGoal.mockResolvedValue([{ id: 'p1' }, { id: 'p2' }])
+    eq.mockResolvedValue({})
+
+    await GoalHandler.getInstance().deleteGoal('g1')
+
+    expect(getProjectsForGoal).toHaveBeenCalledWith('g1')
+    expect(deleteProject).toHaveBeenCalledWith('p1')
+    expect(deleteProject).toHaveBeenCalledWith('p2')
+    expect(deleteFolder).toHaveBeenCalledWith('g1')
+    expect(del).toHaveBeenCalled()
+    expect(eq).toHaveBeenCalledWith('id', 'g1')
+  })
+})
+


### PR DESCRIPTION
## Summary
- add tests covering DocumentHandler upload, retrieval, and recursive deletion
- add tests for GoalHandler goal creation and deletion flows

## Testing
- `npm run lint` *(fails: Mixed spaces and tabs, React must be in scope, and other existing errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ef3c2add8832baca5f072ef853ba7