### PR TITLE
feat: add task creation modal and home task list

### DIFF
--- a/app/src/modals/AddTaskModal.tsx
+++ b/app/src/modals/AddTaskModal.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from 'react'
+import Modal from '@/components/ui/modal'
+import { Task } from '@/models/Task'
+import { Project } from '@/models/Project'
+import { ProjectHandler } from '@/models/ProjectHandler'
+import { TaskHandler } from '@/models/TaskHandler'
+
+interface AddTaskModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onCreated?: (task: Task) => void
+}
+
+export default function AddTaskModal({ isOpen, onClose, onCreated }: AddTaskModalProps) {
+  const [projects, setProjects] = useState<Project[]>([])
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [deadline, setDeadline] = useState('')
+  const [duration, setDuration] = useState(1)
+  const [projectId, setProjectId] = useState('')
+
+  useEffect(() => {
+    ProjectHandler.getInstance()
+      .getProjects()
+      .then(list => {
+        setProjects(list)
+        if (list.length > 0 && !projectId) setProjectId(list[0].id)
+      })
+      .catch(() => setProjects([]))
+  }, [projectId])
+
+  const handleCreate = async () => {
+    const project = projects.find(p => p.id === projectId) || null
+    const task = new Task(
+      crypto.randomUUID(),
+      name,
+      description,
+      new Date(deadline),
+      project,
+      duration * 3600,
+      [],
+    )
+    await TaskHandler.getInstance().createTask(task)
+    if (onCreated) onCreated(task)
+    onClose()
+    setName('')
+    setDescription('')
+    setDeadline('')
+    setDuration(1)
+    setProjectId(projects[0]?.id ?? '')
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Add Task">
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            className="w-full p-2 border border-gray-300 rounded"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+          <textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            className="w-full p-2 border border-gray-300 rounded"
+          />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Deadline</label>
+            <input
+              type="date"
+              value={deadline}
+              onChange={e => setDeadline(e.target.value)}
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Duration (h)</label>
+            <input
+              type="number"
+              value={duration}
+              onChange={e => setDuration(Number(e.target.value))}
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Project</label>
+            <select
+              value={projectId}
+              onChange={e => setProjectId(e.target.value)}
+              className="w-full p-2 border border-gray-300 rounded"
+            >
+              {projects.map(p => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="flex justify-end pt-2">
+          <button
+            onClick={handleCreate}
+            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+          >
+            Create Task
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/app/src/models/TaskHandler.test.ts
+++ b/app/src/models/TaskHandler.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { TaskHandler } from './TaskHandler'
+import { Task } from './Task'
+import { Project } from './Project'
+import { Goal } from './Goal'
+import { AOL } from './AOL'
+
+const { authGetUser, insert, from } = vi.hoisted(() => {
+  const insert = vi.fn()
+  const from = vi.fn(() => ({ insert }))
+  return {
+    authGetUser: vi.fn(),
+    insert,
+    from,
+  }
+})
+
+vi.mock('../../supabase', () => ({ default: { auth: { getUser: authGetUser }, from } }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  TaskHandler.reset()
+})
+
+describe('TaskHandler', () => {
+  test('createTask inserts task', async () => {
+    authGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+    insert.mockResolvedValue({})
+    const goal = new Goal('g1', 'Goal', '', 0, 0, 0, [new Date(), new Date()], AOL.GROWTH)
+    const project = new Project('p1', 'Project', '', 0, 0, 0, [new Date(), new Date()], goal, 0)
+    const task = new Task('t1', 'Task', 'desc', new Date('2024-01-01'), project, 3600, [])
+    await TaskHandler.getInstance().createTask(task)
+    expect(from).toHaveBeenCalledWith('tasks')
+    expect(insert).toHaveBeenCalledWith({
+      id: 't1',
+      user_id: 'u1',
+      project_id: 'p1',
+      name: 'Task',
+      description: 'desc',
+      deadline: task.deadline.toISOString(),
+      duration: 3600,
+      is_automated: false,
+    })
+  })
+})

--- a/app/src/pages/HomePage.tsx
+++ b/app/src/pages/HomePage.tsx
@@ -1,12 +1,62 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react'
+import { Task } from '@/models/Task'
+import { TaskHandler } from '@/models/TaskHandler'
+import AddTaskModal from '@/modals/AddTaskModal'
 
 export default function HomePage() {
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [showModal, setShowModal] = useState(false)
+  const handler = React.useMemo(() => TaskHandler.getInstance(), [])
+
+  useEffect(() => {
+    handler
+      .getTasks()
+      .then(setTasks)
+      .catch(() => setTasks([]))
+  }, [handler])
+
   return (
-    <section className="bg-white p-4 sm:p-6 rounded-lg shadow space-y-2">
-      <h1 className="text-2xl font-bold">Welcome to LifeManager</h1>
-      <p className="text-gray-700">
-        Manage your habits, projects and goals from a single dashboard.
-      </p>
+    <section className="space-y-4">
+      <div className="bg-white p-4 sm:p-6 rounded-lg shadow space-y-2">
+        <h1 className="text-2xl font-bold">Welcome to LifeManager</h1>
+        <p className="text-gray-700">
+          Manage your habits, projects and goals from a single dashboard.
+        </p>
+      </div>
+
+      <div className="bg-white shadow rounded p-4 text-gray-800">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-bold">Tasks</h2>
+          <button
+            onClick={() => setShowModal(true)}
+            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+          >
+            Add Task
+          </button>
+        </div>
+        {tasks.length > 0 ? (
+          <ul className="list-disc list-inside space-y-1 text-sm">
+            {tasks.map(t => (
+              <li key={t.id} className="flex flex-col">
+                <span className="font-semibold">{t.name}</span>
+                {t.description && <span className="text-gray-600">{t.description}</span>}
+                <span className="text-gray-500 text-xs">
+                  {t.deadline.toLocaleDateString()}
+                  {t.project && ` • ${t.project.name}`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-gray-500 italic text-sm">No tasks yet.</p>
+        )}
+      </div>
+
+      <AddTaskModal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        onCreated={task => setTasks(prev => [...prev, task])}
+      />
     </section>
-  );
+  )
 }

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -17,7 +17,7 @@ app/
 
 ## Pages
 Each file in `pages/` represents a top-level route. Key screens include:
-- `HomePage` – entry point after login.
+- `HomePage` – entry point after login showing all tasks and an option to create new ones.
 - `GoalPage` and `ProjectPage` – manage goals, projects and their tasks.
 - `HabitPage` – track recurring habits.
 - `LoginPage` and `RegisterPage` – authentication flows using Supabase.


### PR DESCRIPTION
## Summary
- add TaskHandler methods to create and fetch tasks
- introduce AddTaskModal for entering task details
- list all tasks on HomePage with an Add Task button
- document HomePage task list and add TaskHandler test

## Testing
- `npm run lint` (fails: Mixed spaces and tabs, React must be in scope)
- `npx eslint app/src/modals/AddTaskModal.tsx app/src/pages/HomePage.tsx app/src/models/TaskHandler.ts app/src/models/TaskHandler.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a485de3c832bbb9915ec8181ff6a