### PR TITLE
feat: add default dates and scrollable tabs

### DIFF
--- a/app/src/components/views/GoalDetailView.tsx
+++ b/app/src/components/views/GoalDetailView.tsx
@@ -125,7 +125,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
   const TabButton: React.FC<TabButtonProps> = ({ tabId, label, icon: Icon, badge }) => (
     <button
       onClick={() => setActiveTab(tabId)}
-      className={`relative flex flex-1 flex-shrink-0 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
+      className={`relative flex flex-shrink-0 sm:flex-1 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
         activeTab === tabId
           ? 'bg-blue-100 text-blue-700'
           : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
@@ -175,7 +175,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({
       </div>
 
       <div className="mb-6 border-b border-gray-200">
-        <nav className="flex space-x-2 overflow-visible whitespace-nowrap pb-2" aria-label="Tabs">
+        <nav className="flex space-x-2 overflow-x-auto whitespace-nowrap pb-2" aria-label="Tabs">
           <TabButton tabId="overview" label="Overview" icon={ChartNoAxesCombined} />
           <TabButton tabId="project" label="Projects" icon={ListTodo} />
           <TabButton tabId="tasks" label="Tasks" icon={Calendar} badge={attentionNeeded} />

--- a/app/src/components/views/ProjectDetailView.tsx
+++ b/app/src/components/views/ProjectDetailView.tsx
@@ -82,7 +82,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
   const TabButton: React.FC<TabButtonProps> = ({ tabId, label, icon: Icon, badge }) => (
     <button
       onClick={() => setActiveTab(tabId)}
-      className={`relative flex flex-1 flex-shrink-0 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
+      className={`relative flex flex-shrink-0 sm:flex-1 items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition ${
         activeTab === tabId
           ? 'bg-blue-100 text-blue-700'
           : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
@@ -118,7 +118,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
         </button>
       </div>
       <div className="mb-6 border-b border-gray-200">
-        <nav className="flex space-x-2 overflow-visible whitespace-nowrap pb-2" aria-label="Tabs">
+        <nav className="flex space-x-2 overflow-x-auto whitespace-nowrap pb-2" aria-label="Tabs">
           <TabButton tabId="overview" label="Overview" icon={ChartNoAxesCombined} />
           <TabButton tabId="tasks" label="Tasks" icon={Calendar} badge={attentionNeeded} />
           <TabButton tabId="topics" label="Topics" icon={Tags} />

--- a/app/src/modals/AddGoalModal.tsx
+++ b/app/src/modals/AddGoalModal.tsx
@@ -16,8 +16,14 @@ export default function AddGoalModal({ isOpen, onClose, onCreated }: AddGoalModa
   const [start, setStart] = useState(0);
   const [current, setCurrent] = useState(0);
   const [objective, setObjective] = useState(1);
-  const [periodFrom, setPeriodFrom] = useState('');
-  const [periodTo, setPeriodTo] = useState('');
+  const todayStr = () => new Date().toISOString().split('T')[0];
+  const nextYearStr = () => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() + 1);
+    return d.toISOString().split('T')[0];
+  };
+  const [periodFrom, setPeriodFrom] = useState(todayStr());
+  const [periodTo, setPeriodTo] = useState(nextYearStr());
   const [aol, setAol] = useState<AOL>(AOL.GROWTH);
 
   const handleCreate = async () => {
@@ -40,8 +46,8 @@ export default function AddGoalModal({ isOpen, onClose, onCreated }: AddGoalModa
     setStart(0);
     setCurrent(0);
     setObjective(1);
-    setPeriodFrom('');
-    setPeriodTo('');
+    setPeriodFrom(todayStr());
+    setPeriodTo(nextYearStr());
     setAol(AOL.GROWTH);
   };
 

--- a/app/src/modals/AddProjectModal.tsx
+++ b/app/src/modals/AddProjectModal.tsx
@@ -24,8 +24,14 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
   const [start, setStart] = useState(0);
   const [current, setCurrent] = useState(0);
   const [objective, setObjective] = useState(1);
-  const [periodFrom, setPeriodFrom] = useState('');
-  const [periodTo, setPeriodTo] = useState('');
+  const todayStr = () => new Date().toISOString().split('T')[0];
+  const nextYearStr = () => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() + 1);
+    return d.toISOString().split('T')[0];
+  };
+  const [periodFrom, setPeriodFrom] = useState(todayStr());
+  const [periodTo, setPeriodTo] = useState(nextYearStr());
   const [contributionPct, setContributionPct] = useState(0);
   const [goalId, setGoalId] = useState('');
   useEffect(() => {
@@ -56,8 +62,8 @@ export default function AddProjectModal({ isOpen, onClose, onCreated }: AddProje
     setStart(0);
     setCurrent(0);
     setObjective(1);
-    setPeriodFrom('');
-    setPeriodTo('');
+    setPeriodFrom(todayStr());
+    setPeriodTo(nextYearStr());
     setContributionPct(0);
     setGoalId(goals[0]?.id ?? '');
   };

--- a/app/src/modals/AddTaskModal.tsx
+++ b/app/src/modals/AddTaskModal.tsx
@@ -21,7 +21,12 @@ export default function AddTaskModal({
   const [projects, setProjects] = useState<Project[]>([])
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
-  const [deadline, setDeadline] = useState('')
+  const defaultDeadline = () => {
+    const d = new Date()
+    d.setDate(d.getDate() + 7)
+    return d.toISOString().split('T')[0]
+  }
+  const [deadline, setDeadline] = useState(defaultDeadline())
   const [duration, setDuration] = useState(1)
   const [projectId, setProjectId] = useState(defaultProjectId || '')
 
@@ -55,7 +60,7 @@ export default function AddTaskModal({
     onClose()
     setName('')
     setDescription('')
-    setDeadline('')
+    setDeadline(defaultDeadline())
     setDuration(1)
     setProjectId(defaultProjectId ?? projects[0]?.id ?? '')
   }


### PR DESCRIPTION
## Summary
- allow horizontal scrolling for goal and project tabs on small screens
- pre-fill date fields in goal, project, and task modals with sensible defaults

## Testing
- `npm test`
- `npm run lint` *(fails: mixed spaces/tabs and missing React scope in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a5abca8ed4832bbd8774447f7cbccc